### PR TITLE
feat: add _skills/ with non-monolith skills layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ Repository = "https://github.com/ywatanabe1989/crossref_local"
 [tool.hatch.build.targets.wheel]
 packages = ["src/crossref_local"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/crossref_local/_skills" = "crossref_local/_skills"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/src/crossref_local/_skills/SKILL.md
+++ b/src/crossref_local/_skills/SKILL.md
@@ -1,0 +1,79 @@
+---
+package: crossref-local
+version: 0.6.4
+description: Local CrossRef database with 167M+ works and full-text search
+---
+
+# crossref-local Skills Index
+
+Local mirror of the CrossRef database. Full-text search across 167M+ scholarly
+works, citation network analysis, and paper cache management — all offline, no
+rate limits.
+
+## Sub-skill Files
+
+| File | Topic |
+|------|-------|
+| [crossref-local/01_configuration.md](crossref-local/01_configuration.md) | Setup, env vars, DB vs HTTP mode |
+| [crossref-local/02_search.md](crossref-local/02_search.md) | `search()`, `count()`, `exists()`, FTS5 syntax |
+| [crossref-local/03_retrieval.md](crossref-local/03_retrieval.md) | `get()`, `get_many()`, `enrich()`, `enrich_dois()` |
+| [crossref-local/04_models.md](crossref-local/04_models.md) | `Work`, `SearchResult` dataclasses and methods |
+| [crossref-local/05_citations.md](crossref-local/05_citations.md) | `get_citing()`, `get_cited()`, `CitationNetwork` |
+| [crossref-local/06_checker.md](crossref-local/06_checker.md) | `check_citations()`, `check_bibtex()`, `check_doi_list()` |
+| [crossref-local/07_cache.md](crossref-local/07_cache.md) | `cache.create()`, `cache.query()`, `cache.stats()` |
+| [crossref-local/08_export.md](crossref-local/08_export.md) | `save()`, formats: json/bibtex/text |
+| [crossref-local/09_async.md](crossref-local/09_async.md) | `aio.search()`, `aio.count_many()` |
+| [crossref-local/10_cli.md](crossref-local/10_cli.md) | CLI commands: search, check, relay, mcp |
+| [crossref-local/11_mcp.md](crossref-local/11_mcp.md) | MCP server tools and client config |
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `search` | FTS5 full-text search across 167M+ papers |
+| `search_by_doi` | Lookup by DOI, returns full metadata |
+| `status` | Database stats (works, FTS indexed, citations) |
+| `enrich_dois` | Fetch full metadata for a list of DOIs |
+| `check_citations` | Validate DOI list against database |
+| `check_bibtex_file` | Validate all DOIs in a .bib file |
+| `cache_create` | Build topic cache from search query |
+| `cache_query` | Filter/project cached papers |
+| `cache_stats` | Year distribution, top journals, citation stats |
+| `cache_list` | List all caches |
+| `cache_top_cited` | Top cited papers from cache |
+| `cache_citation_summary` | Citation statistics for cache |
+| `cache_plot_scatter` | Year vs citations scatter plot |
+| `cache_plot_network` | Interactive citation network HTML |
+| `cache_export` | Export cache to json/csv/bibtex/dois |
+
+## CLI Summary
+
+```
+crossref-local search QUERY [-n N] [-a] [-A] [-if] [--json] [--save FILE]
+crossref-local search-by-doi DOI [--json] [--citation] [--save FILE]
+crossref-local check [FILE] [-d DOI] [--json] [--save FILE]
+crossref-local status [--json]
+crossref-local relay [--port PORT] [--force]
+crossref-local mcp start [-t stdio|http|sse] [--host HOST] [--port PORT]
+crossref-local mcp doctor
+crossref-local mcp installation
+crossref-local mcp list-tools [-v|-vv|-vvv]
+```
+
+## Quick Start
+
+```python
+import crossref_local as crl
+
+# Configure (or set CROSSREF_LOCAL_DB env var)
+crl.configure("/path/to/crossref.db")
+
+# Search
+results = crl.search("hippocampal sharp wave ripples", limit=10)
+
+# Retrieve by DOI
+work = crl.get("10.1126/science.aax0758")
+
+# Check citations
+result = crl.check_bibtex("bibliography.bib")
+```

--- a/src/crossref_local/_skills/crossref-local/01_configuration.md
+++ b/src/crossref_local/_skills/crossref-local/01_configuration.md
@@ -1,0 +1,85 @@
+---
+package: crossref-local
+skill: configuration
+---
+
+# Configuration
+
+crossref-local supports two access modes: direct SQLite (`db`) and HTTP API
+(`http`). Mode is auto-detected from environment variables.
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CROSSREF_LOCAL_DB` | Path to SQLite database file | auto-detect |
+| `SCITEX_SCHOLAR_CROSSREF_DB` | Alternative DB path (higher priority) | — |
+| `CROSSREF_LOCAL_API_URL` | HTTP API URL | `http://localhost:31291` |
+| `CROSSREF_LOCAL_MODE` | Force mode: `db`, `http`, or `auto` | `auto` |
+| `CROSSREF_LOCAL_HOST` | Relay server bind host | `0.0.0.0` |
+| `CROSSREF_LOCAL_PORT` | Relay server port | `31291` |
+| `CROSSREF_LOCAL_MCP_HOST` | MCP HTTP server host | `localhost` |
+| `CROSSREF_LOCAL_MCP_PORT` | MCP HTTP server port | `8082` |
+
+## Auto-Detection Order
+
+1. `SCITEX_SCHOLAR_CROSSREF_DB` env var
+2. `CROSSREF_LOCAL_DB` env var
+3. `./data/crossref.db` (cwd)
+4. `~/.crossref_local/crossref.db`
+
+## Python API
+
+```python
+import crossref_local as crl
+
+# DB mode — direct SQLite access
+crl.configure("/path/to/crossref.db")
+
+# HTTP mode — connect to relay server
+crl.configure_http("http://localhost:31291")
+crl.configure_http()  # uses default http://localhost:31291
+
+# configure_remote is a backward-compat alias for configure_http
+crl.configure_remote("http://myserver:31291")
+
+# Query current mode
+mode = crl.get_mode()   # returns "db" or "http"
+
+# Get database statistics
+info = crl.info()
+# Returns: {"mode": "db", "status": "ok", "db_path": "...",
+#           "works": 167_000_000, "fts_indexed": ..., "citations": ...}
+```
+
+## Signatures
+
+```python
+configure(db_path: str) -> None
+configure_http(api_url: str = "http://localhost:31291") -> None
+configure_remote(api_url: str = "http://localhost:31291") -> None  # alias
+get_mode() -> str   # "db" or "http"
+info() -> dict
+```
+
+## SSH Tunnel (Remote DB)
+
+```bash
+# On local machine: tunnel port 31291 from remote server
+ssh -L 31291:127.0.0.1:31291 your-server
+
+# In Python
+crl.configure_http()   # default localhost:31291 — now tunneled to server
+```
+
+## HTTP Relay Server
+
+Start a relay server to expose the local SQLite DB over HTTP:
+
+```bash
+crossref-local relay                    # binds 0.0.0.0:31291
+crossref-local relay --port 8080        # custom port
+crossref-local relay --force            # kill existing process on port
+```
+
+`run_server` is implemented in `crossref_local._server`.

--- a/src/crossref_local/_skills/crossref-local/02_search.md
+++ b/src/crossref_local/_skills/crossref-local/02_search.md
@@ -1,0 +1,107 @@
+---
+package: crossref-local
+skill: search
+---
+
+# Search
+
+Full-text search across titles, abstracts, and authors using SQLite FTS5 index.
+
+## Signatures
+
+```python
+search(
+    query: str,
+    limit: int = 10,
+    offset: int = 0,
+    with_if: bool = False,
+) -> SearchResult
+
+count(query: str) -> int
+
+exists(doi: str) -> bool
+```
+
+## Parameters
+
+### `search()`
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | str | required | FTS5 search query |
+| `limit` | int | 10 | Max results to return |
+| `offset` | int | 0 | Skip first N results (pagination) |
+| `with_if` | bool | False | Include OpenAlex impact factor data |
+
+### `count()`
+
+Returns total number of matching works without fetching results. Efficient for
+pagination planning.
+
+### `exists()`
+
+Returns `True` if the DOI is present in the database.
+
+## FTS5 Query Syntax
+
+| Syntax | Meaning | Example |
+|--------|---------|---------|
+| `word` | Match word | `CRISPR` |
+| `"exact phrase"` | Exact phrase | `"sharp wave ripples"` |
+| `word1 AND word2` | Both required | `neural AND network` |
+| `word1 OR word2` | Either | `hippocampus OR cortex` |
+| `word1 NOT word2` | Exclude | `seizure NOT epilepsy` |
+| `word*` | Prefix match | `neuro*` |
+
+## Examples
+
+```python
+import crossref_local as crl
+
+# Basic search
+results = crl.search("hippocampal sharp wave ripples")
+print(f"Found {results.total:,} matches in {results.elapsed_ms:.1f}ms")
+for work in results:
+    print(f"  {work.title} ({work.year}) DOI:{work.doi}")
+
+# Paginate
+page1 = crl.search("machine learning", limit=20, offset=0)
+page2 = crl.search("machine learning", limit=20, offset=20)
+
+# Count only
+n = crl.count("CRISPR AND cancer")
+print(f"{n:,} papers on CRISPR and cancer")
+
+# Check existence
+if crl.exists("10.1038/nature12373"):
+    print("DOI is in database")
+
+# FTS5 operators
+results = crl.search('"deep learning" AND brain NOT review', limit=50)
+
+# With impact factor
+results = crl.search("epilepsy seizure prediction", with_if=True)
+for work in results:
+    if work.impact_factor:
+        print(f"IF {work.impact_factor:.1f}: {work.title}")
+```
+
+## `@supports_return_as` Decorator
+
+All search functions are decorated with `@supports_return_as` from
+`scitex_dev`, enabling alternate return formats:
+
+```python
+# Return as pandas DataFrame
+df = crl.search("CRISPR", limit=100, return_as="dataframe")
+
+# Return as JSON string
+json_str = crl.count("deep learning", return_as="json")
+```
+
+## Performance Notes
+
+- FTS5 index covers titles, abstracts, and authors
+- Typical search latency: 5–50ms for common queries
+- `count()` is slightly faster than `search()` for existence checks
+- `exists()` uses a direct indexed lookup — fastest for single DOI checks

--- a/src/crossref_local/_skills/crossref-local/03_retrieval.md
+++ b/src/crossref_local/_skills/crossref-local/03_retrieval.md
@@ -1,0 +1,99 @@
+---
+package: crossref-local
+skill: retrieval
+---
+
+# Retrieval
+
+Fetch full metadata for one or many DOIs, and enrich search results with
+citation counts and reference lists.
+
+## Signatures
+
+```python
+get(doi: str) -> Work | None
+
+get_many(dois: list[str]) -> list[Work]
+
+enrich(
+    results: SearchResult,
+    include_citations: bool = True,
+    include_references: bool = True,
+) -> SearchResult
+
+enrich_dois(
+    dois: list[str],
+    include_citations: bool = True,
+    include_references: bool = True,
+) -> list[Work]
+```
+
+## `get()` — Single DOI Lookup
+
+Returns `None` if not found; never raises for missing DOIs.
+
+```python
+import crossref_local as crl
+
+work = crl.get("10.1038/nature12373")
+if work:
+    print(work.title)
+    print(work.citation_count)
+    print(work.to_bibtex())
+```
+
+## `get_many()` — Batch Lookup
+
+Missing DOIs are silently skipped (no exception).
+
+```python
+dois = ["10.1038/nature12373", "10.1126/science.aax0758", "10.xxxx/invalid"]
+works = crl.get_many(dois)
+# Returns 2 Work objects; invalid DOI is skipped
+```
+
+## `enrich()` — Enrich SearchResult
+
+`search()` returns lightweight metadata for speed. `enrich()` fetches full
+metadata for each work in the result, adding `citation_count` and `references`.
+
+```python
+results = crl.search("machine learning", limit=10)
+enriched = crl.enrich(results)
+for work in enriched:
+    print(f"{work.title}: {work.citation_count} citations, "
+          f"{len(work.references)} references")
+```
+
+## `enrich_dois()` — Enrich DOI List
+
+Convenience wrapper around `get_many()` for a list of DOIs.
+
+```python
+dois = ["10.1038/nature12373", "10.1126/science.aax0758"]
+works = crl.enrich_dois(dois)
+for w in works:
+    print(f"{w.doi}: {w.citation_count} citations, {len(w.references)} refs")
+```
+
+## Typical Workflow
+
+```python
+# 1. Search for papers (fast, basic metadata)
+results = crl.search("hippocampal replay", limit=20)
+
+# 2. Get DOIs of most relevant papers
+doi_list = [w.doi for w in results[:5]]
+
+# 3. Enrich with full metadata
+works = crl.enrich_dois(doi_list)
+
+# 4. Save as BibTeX
+crl.save(works, "papers.bib", format="bibtex")
+```
+
+## Notes
+
+- `search()` is faster than `get()` for initial discovery
+- `enrich()` makes N database calls (one per work) — use `get_many()` for batch
+- Both `enrich()` and `enrich_dois()` are decorated with `@supports_return_as`

--- a/src/crossref_local/_skills/crossref-local/04_models.md
+++ b/src/crossref_local/_skills/crossref-local/04_models.md
@@ -1,0 +1,139 @@
+---
+package: crossref-local
+skill: models
+---
+
+# Data Models
+
+## `Work` Dataclass
+
+Represents a single scholarly work from CrossRef.
+
+```python
+@dataclass
+class Work:
+    doi: str
+    title: Optional[str] = None
+    authors: List[str] = field(default_factory=list)
+    year: Optional[int] = None
+    journal: Optional[str] = None
+    issn: Optional[str] = None
+    volume: Optional[str] = None
+    issue: Optional[str] = None
+    page: Optional[str] = None
+    publisher: Optional[str] = None
+    type: Optional[str] = None          # "journal-article", "book-chapter", etc.
+    abstract: Optional[str] = None
+    url: Optional[str] = None
+    citation_count: Optional[int] = None
+    references: List[str] = field(default_factory=list)  # list of DOIs
+    impact_factor: Optional[float] = None
+    impact_factor_source: Optional[str] = None
+```
+
+### Work Methods
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `to_dict()` | `() -> dict` | All fields as dict |
+| `to_text()` | `(include_abstract: bool = False) -> str` | Human-readable text |
+| `to_bibtex()` | `() -> str` | BibTeX entry string |
+| `citation()` | `(style: str = "apa") -> str` | Formatted APA citation |
+| `save()` | `(path: str, format: str = "json") -> str` | Path to saved file |
+| `from_metadata()` | `(doi, metadata: dict) -> Work` | classmethod from raw CrossRef JSON |
+
+### Work Examples
+
+```python
+work = crl.get("10.1038/nature12373")
+
+# Format as citation
+print(work.citation())
+# -> "Malenka R, ..., (2013). ..."
+
+# Convert to dict
+d = work.to_dict()
+# Keys: doi, title, authors, year, journal, issn, volume, issue,
+#       page, publisher, type, abstract, url, citation_count,
+#       references, impact_factor, impact_factor_source
+
+# Format as BibTeX
+bib = work.to_bibtex()
+
+# Save to files
+work.save("paper.json")
+work.save("paper.bib", format="bibtex")
+work.save("paper.txt", format="text")
+
+# Human-readable
+print(work.to_text(include_abstract=True))
+```
+
+### CrossRef Work Types
+
+| CrossRef type | BibTeX type |
+|--------------|-------------|
+| `journal-article` | `article` |
+| `book-chapter` | `incollection` |
+| `book` | `book` |
+| `proceedings-article` | `inproceedings` |
+| `dissertation` | `phdthesis` |
+| `report` | `techreport` |
+| (other) | `misc` |
+
+## `SearchResult` Dataclass
+
+Container returned by `search()`.
+
+```python
+@dataclass
+class SearchResult:
+    works: List[Work]
+    total: int         # total matches (may exceed len(works))
+    query: str         # original query string
+    elapsed_ms: float  # search duration in milliseconds
+    limit_info: Optional[LimitInfo] = None
+```
+
+### SearchResult Methods
+
+| Method | Signature | Returns |
+|--------|-----------|---------|
+| `__len__()` | `() -> int` | `len(works)` |
+| `__iter__()` | | iterates over works |
+| `__getitem__()` | `(idx)` | `works[idx]` |
+| `save()` | `(path, format="json", include_abstract=True) -> str` | Path to file |
+
+```python
+results = crl.search("CRISPR", limit=20)
+print(len(results))          # 20 (returned)
+print(results.total)         # potentially millions
+print(results.elapsed_ms)    # e.g., 12.3
+
+# Iterate
+for work in results:
+    print(work.doi)
+
+# Index
+first = results[0]
+
+# Save
+results.save("results.json")
+results.save("results.bib", format="bibtex")
+results.save("results.txt", format="text", include_abstract=False)
+```
+
+## `LimitInfo` Dataclass
+
+Metadata about result limiting (useful in layered deployments).
+
+```python
+@dataclass
+class LimitInfo:
+    requested: int
+    returned: int
+    total_available: int
+    capped: bool = False
+    capped_reason: Optional[str] = None
+    stage: str = "crossref-local"
+```

--- a/src/crossref_local/_skills/crossref-local/05_citations.md
+++ b/src/crossref_local/_skills/crossref-local/05_citations.md
@@ -1,0 +1,121 @@
+---
+package: crossref-local
+skill: citations
+---
+
+# Citation Analysis
+
+Build and visualize citation networks from the local database.
+
+## Signatures
+
+```python
+get_citing(doi: str, limit: int = 100) -> list[str]
+
+get_cited(doi: str, limit: int = 100) -> list[str]
+
+get_citation_count(doi: str) -> int
+
+class CitationNetwork:
+    def __init__(
+        self,
+        center_doi: str,
+        depth: int = 1,
+        max_citing: int = 50,
+        max_cited: int = 50,
+    ): ...
+
+    nodes: Dict[str, CitationNode]
+    edges: List[CitationEdge]
+
+    def save_html(self, path: str = "citation_network.html", **kwargs) -> str
+    def save_png(self, path: str = "citation_network.png",
+                 figsize: tuple = (12, 10)) -> str
+    def to_networkx(self) -> nx.DiGraph
+    def to_dict(self) -> dict
+```
+
+## `get_citing()` — Papers that Cite a DOI
+
+Returns DOIs of papers that cite the given paper.
+
+```python
+import crossref_local as crl
+
+citing = crl.get_citing("10.1038/nature12373", limit=50)
+print(f"Cited by {len(citing)} papers")
+```
+
+## `get_cited()` — Papers a DOI Cites
+
+Returns DOIs of papers cited by the given paper (its reference list).
+
+```python
+references = crl.get_cited("10.1038/nature12373", limit=100)
+print(f"Cites {len(references)} papers")
+```
+
+## `get_citation_count()` — Count Inbound Citations
+
+```python
+n = crl.get_citation_count("10.1038/nature12373")
+print(f"Cited {n} times")
+```
+
+## `CitationNetwork` — Citation Graph
+
+Builds a directed graph of papers connected by citations, similar to
+Connected Papers. Requires the `viz` extra: `pip install crossref-local[viz]`.
+
+```python
+from crossref_local import CitationNetwork
+
+# Build network around a paper (depth=1 = direct citations only)
+network = CitationNetwork("10.1038/nature12373", depth=2, max_citing=30)
+print(f"Nodes: {len(network.nodes)}, Edges: {len(network.edges)}")
+
+# Interactive HTML (requires pyvis)
+network.save_html("network.html")
+
+# Static PNG (requires matplotlib + networkx)
+network.save_png("network.png", figsize=(14, 12))
+
+# Export as dict
+data = network.to_dict()
+# Keys: center_doi, depth, nodes, edges, stats
+
+# Convert to NetworkX DiGraph (requires networkx)
+G = network.to_networkx()
+```
+
+## `CitationNode` Dataclass
+
+```python
+@dataclass
+class CitationNode:
+    doi: str
+    title: str = ""
+    authors: List[str] = field(default_factory=list)
+    year: Optional[int] = None
+    journal: str = ""
+    citation_count: int = 0
+    depth: int = 0     # 0 = center node
+```
+
+## `CitationEdge` Dataclass
+
+```python
+@dataclass
+class CitationEdge:
+    citing_doi: str
+    cited_doi: str
+    year: Optional[int] = None
+```
+
+## Notes
+
+- Data comes from CrossRef `reference` fields — coverage varies by publisher
+- `depth=2` can generate large graphs; use `max_citing` and `max_cited` to limit
+- Node size in `save_html()` is proportional to `log(citation_count)`
+- Node color in HTML encodes depth (red=center, blue=depth1, green=depth2…)
+- `get_citing`, `get_cited`, `get_citation_count` support `@supports_return_as`

--- a/src/crossref_local/_skills/crossref-local/06_checker.md
+++ b/src/crossref_local/_skills/crossref-local/06_checker.md
@@ -1,0 +1,139 @@
+---
+package: crossref-local
+skill: checker
+---
+
+# Citation Checker
+
+Validate that DOIs exist in the local database and check metadata completeness.
+Useful for proofreading BibTeX files and DOI lists before submission.
+
+## Signatures
+
+```python
+check_citations(
+    identifiers: list[str],
+    source_keys: Optional[list[str]] = None,
+    titles: Optional[list[str]] = None,
+    validate_metadata: bool = True,
+    suggest_enrichment: bool = True,
+) -> CheckResult
+
+check_bibtex(
+    bib_path: str | Path,
+    validate_metadata: bool = True,
+    suggest_enrichment: bool = True,
+) -> CheckResult
+
+check_doi_list(
+    list_path: str | Path,
+    validate_metadata: bool = True,
+    suggest_enrichment: bool = True,
+) -> CheckResult
+```
+
+## `CheckResult` Dataclass
+
+```python
+@dataclass
+class CheckResult:
+    entries: List[CitationEntry]
+    total: int
+    found: int
+    missing: int
+    with_issues: int
+    elapsed_ms: float
+
+    def to_dict(self) -> dict
+    def save(self, path: str | Path, format: str = "json") -> str
+    # format: "json" or "text"
+```
+
+## `CitationEntry` Dataclass
+
+```python
+@dataclass
+class CitationEntry:
+    identifier: str            # original DOI string
+    source_key: Optional[str]  # BibTeX key (if from .bib file)
+    title: Optional[str]       # title from BibTeX (if available)
+    found: bool                # True if DOI exists in DB
+    work: Optional[Work]       # Work object if found
+    issues: List[str]          # metadata issues (missing abstract, etc.)
+    suggestions: List[str]     # improvement suggestions
+```
+
+## Examples
+
+### Check a List of DOIs
+
+```python
+import crossref_local as crl
+
+result = crl.check_citations([
+    "10.1038/nature12373",
+    "10.1126/science.aax0758",
+    "10.xxxx/invalid-doi",
+])
+print(f"Found: {result.found}/{result.total}")
+
+for entry in result:
+    status = "OK" if entry.found else "MISSING"
+    print(f"  [{status}] {entry.identifier}")
+    for issue in entry.issues:
+        print(f"    ! {issue}")
+```
+
+### Check BibTeX File
+
+Requires `bibtexparser`: `pip install bibtexparser`
+
+```python
+result = crl.check_bibtex("bibliography.bib")
+print(f"Found: {result.found}/{result.total}")
+
+# Missing citations
+missing = [e for e in result if not e.found]
+for e in missing:
+    print(f"  MISSING: {e.source_key} ({e.identifier})")
+
+# Save report
+result.save("check_report.json")
+result.save("check_report.txt", format="text")
+```
+
+### Check DOI List File
+
+Accepts one DOI per line, or comma-separated. Lines starting with `#` are
+comments.
+
+```
+# dois.txt
+10.1038/nature12373
+10.1126/science.aax0758
+# 10.xxxx/commented-out
+```
+
+```python
+result = crl.check_doi_list("dois.txt")
+```
+
+## Metadata Validation
+
+When `validate_metadata=True`, each found DOI is checked for:
+
+| Check | Issue reported |
+|-------|---------------|
+| Missing abstract | "Missing abstract in database" |
+| Missing authors | "Missing author list" |
+| Missing year | "Missing publication year" |
+
+## CLI Usage
+
+```bash
+crossref-local check bibliography.bib
+crossref-local check dois.txt
+crossref-local check -d 10.1038/nature12373 -d 10.1126/science.aax0758
+crossref-local check bibliography.bib --json
+crossref-local check bibliography.bib --save report.json
+```

--- a/src/crossref_local/_skills/crossref-local/07_cache.md
+++ b/src/crossref_local/_skills/crossref-local/07_cache.md
@@ -1,0 +1,146 @@
+---
+package: crossref-local
+skill: cache
+---
+
+# Paper Cache
+
+Disk-based caching of paper metadata for efficient re-querying and reduced
+context usage. Stored in `~/.crossref_local/` as JSON files.
+
+## Public API (`crossref_local.cache`)
+
+```python
+from crossref_local import cache
+
+cache.create(name, query=None, dois=None, papers=None,
+             limit=1000, offset=0) -> CacheInfo
+cache.append(name, query=None, dois=None, limit=1000, offset=0) -> CacheInfo
+cache.load(name) -> list[dict]
+cache.query(name, fields=None, include_abstract=False,
+            include_references=False, include_citations=False,
+            year_min=None, year_max=None, journal=None,
+            limit=None) -> list[dict]
+cache.query_dois(name) -> list[str]
+cache.stats(name) -> dict
+cache.info(name) -> CacheInfo
+cache.exists(name) -> bool
+cache.list_caches() -> list[CacheInfo]
+cache.delete(name) -> bool
+cache.export(name, output_path, format="json", fields=None) -> str
+```
+
+## `CacheInfo` Dataclass
+
+```python
+@dataclass
+class CacheInfo:
+    name: str
+    path: str
+    size_bytes: int
+    paper_count: int
+    created_at: str
+    query: Optional[str] = None
+
+    def to_dict(self) -> dict  # includes size_mb
+```
+
+## Workflows
+
+### Build a Topic Cache
+
+```python
+from crossref_local import cache
+
+# From search query
+info = cache.create("epilepsy", query="epilepsy seizure prediction", limit=500)
+print(f"Cached {info.paper_count} papers ({info.size_bytes / 1e6:.1f} MB)")
+
+# From explicit DOIs
+info = cache.create("my_papers", dois=["10.1038/nature12373", ...])
+
+# From pre-fetched dicts (skips DB calls)
+papers = [{"doi": "...", "title": "..."}]
+info = cache.create("imported", papers=papers)
+```
+
+### Query with Field Projection
+
+```python
+# Minimal fields — efficient for context
+papers = cache.query("epilepsy", fields=["doi", "title", "year"])
+
+# Default fields: doi, title, authors, year, journal
+papers = cache.query("epilepsy")
+
+# Add optional fields
+papers = cache.query("epilepsy",
+                     include_abstract=True,
+                     include_citations=True,
+                     include_references=True)
+
+# With filters
+papers = cache.query("epilepsy",
+                     year_min=2018, year_max=2024,
+                     journal="Nature",
+                     limit=50)
+```
+
+### Statistics
+
+```python
+stats = cache.stats("epilepsy")
+# Returns:
+# {
+#   "paper_count": 487,
+#   "year_range": {"min": 1995, "max": 2024},
+#   "year_distribution": {2020: 45, 2021: 62, ...},
+#   "with_abstract": 312,
+#   "abstract_coverage": 64.1,
+#   "top_journals": [{"journal": "Brain", "count": 23}, ...],
+#   "citation_stats": {"total": 45321, "mean": 93.1, "max": 8432}
+# }
+```
+
+### Cache Management
+
+```python
+# List all caches
+for ci in cache.list_caches():
+    print(f"{ci.name}: {ci.paper_count} papers")
+
+# Check if exists
+if cache.exists("epilepsy"):
+    ...
+
+# Append new papers
+cache.append("epilepsy", query="seizure threshold", limit=200)
+
+# Get just DOIs
+dois = cache.query_dois("epilepsy")
+
+# Export
+cache.export("epilepsy", "papers.bib", format="bibtex")
+cache.export("epilepsy", "papers.csv", format="csv")
+cache.export("epilepsy", "dois.txt", format="dois")
+cache.export("epilepsy", "papers.json", format="json")
+
+# Delete
+cache.delete("epilepsy")
+```
+
+## Export Formats
+
+| Format | Description |
+|--------|-------------|
+| `json` | List of paper dicts |
+| `csv` | Tabular format |
+| `bibtex` | BibTeX entries |
+| `dois` | One DOI per line |
+
+## Cache Directory
+
+Default: `~/.crossref_local/`
+
+- `{name}.json` — paper data
+- `{name}.meta.json` — creation metadata (query, timestamps, counts)

--- a/src/crossref_local/_skills/crossref-local/08_export.md
+++ b/src/crossref_local/_skills/crossref-local/08_export.md
@@ -1,0 +1,122 @@
+---
+package: crossref-local
+skill: export
+---
+
+# Export
+
+Save `Work`, `SearchResult`, or lists of `Work` objects to files.
+
+## Signature
+
+```python
+save(
+    data: Work | SearchResult | list[Work],
+    path: str | Path,
+    format: str = "json",
+    include_abstract: bool = True,
+) -> str   # returns path to saved file
+```
+
+## Supported Formats
+
+| Format | Extension | Content |
+|--------|-----------|---------|
+| `json` | `.json` | JSON with all fields; includes query/total/elapsed metadata for SearchResult |
+| `bibtex` | `.bib` | BibTeX entries; type mapped from CrossRef type |
+| `text` | `.txt` | Human-readable; one work per block with optional abstracts |
+
+`SUPPORTED_FORMATS = ["text", "json", "bibtex"]`
+
+## Examples
+
+```python
+import crossref_local as crl
+
+results = crl.search("hippocampal replay", limit=20)
+
+# Save SearchResult
+crl.save(results, "results.json")
+crl.save(results, "results.bib", format="bibtex")
+crl.save(results, "results.txt", format="text", include_abstract=False)
+
+# Save single Work
+work = crl.get("10.1038/nature12373")
+crl.save(work, "paper.json")
+crl.save(work, "paper.bib", format="bibtex")
+
+# Save list of Works
+works = crl.get_many(["10.1038/nature12373", "10.1126/science.aax0758"])
+crl.save(works, "papers.json")
+
+# Via methods on objects
+results.save("results.json")
+results.save("results.bib", format="bibtex")
+work.save("paper.bib", format="bibtex")
+```
+
+## BibTeX Type Mapping
+
+| CrossRef type | BibTeX type |
+|--------------|-------------|
+| `journal-article` | `@article` |
+| `book-chapter` | `@incollection` |
+| `book` | `@book` |
+| `proceedings-article` | `@inproceedings` |
+| `dissertation` | `@phdthesis` |
+| `report` | `@techreport` |
+| (other) | `@misc` |
+
+BibTeX keys are generated from DOIs by replacing `/`, `.`, `-` with `_`.
+
+## JSON Structure
+
+For a `SearchResult`:
+
+```json
+{
+  "query": "hippocampal replay",
+  "total": 42315,
+  "elapsed_ms": 18.4,
+  "works": [
+    {
+      "doi": "10.1038/...",
+      "title": "...",
+      "authors": ["A. Author", "B. Author"],
+      "year": 2021,
+      "journal": "Nature",
+      "issn": "0028-0836",
+      "volume": "591",
+      "issue": "7849",
+      "page": "333-340",
+      "publisher": "Springer Nature",
+      "type": "journal-article",
+      "abstract": "...",
+      "url": "http://dx.doi.org/...",
+      "citation_count": 412,
+      "references": ["10.1038/...", ...],
+      "impact_factor": null,
+      "impact_factor_source": null
+    }
+  ]
+}
+```
+
+## Text Format
+
+```
+Search: hippocampal replay
+Found: 42,315 matches
+Time: 18.4ms
+
+============================================================
+
+[1]
+Hippocampal Replay (2021)
+Authors: A. Author, B. Author
+Journal: Nature, 591(7849), 333-340
+DOI: 10.1038/...
+Citations: 412
+
+----------------------------------------
+```

--- a/src/crossref_local/_skills/crossref-local/09_async.md
+++ b/src/crossref_local/_skills/crossref-local/09_async.md
@@ -1,0 +1,77 @@
+---
+package: crossref-local
+skill: async
+---
+
+# Async API
+
+The `crossref_local.aio` module provides async versions of all core API
+functions using thread pool execution with per-thread database connections.
+
+## Import
+
+```python
+from crossref_local import aio
+# or individual functions
+from crossref_local.aio import search, get, count, count_many
+```
+
+## Available Functions
+
+| Function | Async signature |
+|----------|----------------|
+| `aio.search` | `async (query, limit=10, offset=0, with_if=False) -> SearchResult` |
+| `aio.count` | `async (query) -> int` |
+| `aio.get` | `async (doi) -> Work | None` |
+| `aio.get_many` | `async (dois: list[str]) -> list[Work]` |
+| `aio.exists` | `async (doi) -> bool` |
+| `aio.info` | `async () -> dict` |
+| `aio.search_many` | `async (queries: list[str], ...) -> list[SearchResult]` |
+| `aio.count_many` | `async (queries: list[str]) -> list[int]` |
+
+## Examples
+
+```python
+import asyncio
+from crossref_local import aio
+
+async def main():
+    # Single operations
+    results = await aio.search("hippocampal sharp wave ripples")
+    work = await aio.get("10.1038/nature12373")
+    n = await aio.count("CRISPR AND cancer")
+
+    # Concurrent counts
+    terms = ["CRISPR", "neural network", "epilepsy", "Alzheimer"]
+    counts = await aio.count_many(terms)
+    for term, count in zip(terms, counts):
+        print(f"{term}: {count:,} papers")
+
+    # Concurrent searches
+    queries = ["seizure prediction", "brain-computer interface"]
+    results_list = await aio.search_many(queries, limit=5)
+
+asyncio.run(main())
+```
+
+## `count_many` — Concurrent Counting
+
+Efficient for comparing term frequencies across many queries:
+
+```python
+async def compare_topics():
+    topics = [
+        "deep learning AND medical imaging",
+        "machine learning AND genomics",
+        "natural language processing AND clinical",
+    ]
+    counts = await aio.count_many(topics)
+    for topic, n in sorted(zip(topics, counts), key=lambda x: -x[1]):
+        print(f"{n:>10,}  {topic}")
+```
+
+## Thread Safety
+
+- Each async call runs in a thread pool worker
+- Each worker gets its own database connection (per-thread singletons)
+- Safe for concurrent use without connection pool management

--- a/src/crossref_local/_skills/crossref-local/10_cli.md
+++ b/src/crossref_local/_skills/crossref-local/10_cli.md
@@ -1,0 +1,146 @@
+---
+package: crossref-local
+skill: cli
+---
+
+# Command-Line Interface
+
+Entry point: `crossref-local` (installs from `crossref_local.cli:main`)
+
+## Global Options
+
+```
+crossref-local [--http] [--api-url URL] [--help-recursive] COMMAND
+```
+
+| Option | Description |
+|--------|-------------|
+| `--http` | Force HTTP mode (connect to relay server) |
+| `--api-url URL` | API URL; also via `CROSSREF_LOCAL_API_URL` |
+| `--help-recursive` | Print help for all subcommands |
+| `--version` | Show version |
+
+## Commands
+
+### `search`
+
+```
+crossref-local search QUERY [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-n N`, `--number N` | Number of results (default: 10) |
+| `-o N`, `--offset N` | Skip first N results |
+| `-a`, `--abstracts` | Show abstracts |
+| `-A`, `--authors` | Show author list |
+| `-if`, `--impact-factor` | Show OpenAlex impact factor |
+| `--json` | Output as JSON |
+| `--save FILE` | Save results to file |
+| `--format {text,json,bibtex}` | Format for `--save` (default: json) |
+
+```bash
+crossref-local search "hippocampal sharp wave ripples"
+crossref-local search "CRISPR" -n 20 -a -A --json
+crossref-local search "machine learning" --save papers.bib --format bibtex
+crossref-local search "epilepsy" -n 100 --save results.json
+```
+
+### `search-by-doi`
+
+```
+crossref-local search-by-doi DOI [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Output as JSON |
+| `--citation` | Output formatted APA citation |
+| `--save FILE` | Save to file |
+| `--format {text,json,bibtex}` | Format for `--save` (default: json) |
+
+```bash
+crossref-local search-by-doi 10.1038/nature12373
+crossref-local search-by-doi 10.1038/nature12373 --citation
+crossref-local search-by-doi 10.1038/nature12373 --json
+crossref-local search-by-doi 10.1038/nature12373 --save paper.bib --format bibtex
+```
+
+### `check`
+
+```
+crossref-local check [FILE] [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `FILE` | BibTeX file (.bib) or DOI list file |
+| `-d DOI` | Check specific DOI (repeatable) |
+| `-f {bibtex,doi-list,auto}` | Input format (default: auto-detect) |
+| `--no-validate` | Skip metadata validation |
+| `--no-suggest` | Skip enrichment suggestions |
+| `--json` | Output as JSON |
+| `--save FILE` | Save results to file |
+| `--save-format {json,text}` | Format for `--save` |
+
+```bash
+crossref-local check bibliography.bib
+crossref-local check dois.txt
+crossref-local check -d 10.1038/nature12373 -d 10.1126/science.aax0758
+crossref-local check bibliography.bib --json
+crossref-local check bibliography.bib --save report.json
+# From stdin
+echo "10.1038/nature12373" | crossref-local check
+```
+
+### `status`
+
+```
+crossref-local status [--json]
+```
+
+Shows environment variables, database locations, API health, and counts.
+
+### `relay`
+
+Run an HTTP relay server exposing the SQLite DB over REST.
+
+```
+crossref-local relay [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--host HOST` | Bind host (default: 0.0.0.0, env: `CROSSREF_LOCAL_HOST`) |
+| `--port PORT` | Port (default: 31291, env: `CROSSREF_LOCAL_PORT`) |
+| `--force` | Kill existing process using the port |
+| `--dry-run` | Show what would be started |
+
+```bash
+crossref-local relay
+crossref-local relay --port 8080
+crossref-local relay --force
+```
+
+Requires: `pip install fastapi uvicorn`
+
+### `mcp`
+
+MCP server subcommands. See [11_mcp.md](11_mcp.md).
+
+```bash
+crossref-local mcp start              # stdio (Claude Desktop)
+crossref-local mcp start -t http      # HTTP transport
+crossref-local mcp doctor             # diagnose setup
+crossref-local mcp installation       # show client config
+crossref-local mcp list-tools         # list MCP tools
+crossref-local mcp list-tools -vvv    # with full docs
+```
+
+### `list-python-apis`
+
+```
+crossref-local list-python-apis [-v|-vv|-vvv] [-d DEPTH] [--json]
+```
+
+Lists Python API signatures (delegates to `scitex introspect api`).

--- a/src/crossref_local/_skills/crossref-local/11_mcp.md
+++ b/src/crossref_local/_skills/crossref-local/11_mcp.md
@@ -1,0 +1,173 @@
+---
+package: crossref-local
+skill: mcp
+---
+
+# MCP Server
+
+Exposes crossref-local as Model Context Protocol tools for Claude Desktop,
+Claude Code, and other MCP clients.
+
+Entry points:
+- `crossref-local mcp start` (via CLI)
+- `crossref-local-mcp` (direct entry point, stdio)
+
+Requires: `pip install crossref-local[mcp]` (installs `fastmcp`)
+
+## MCP Tools Reference
+
+### `search`
+
+```
+search(
+    query: str,
+    limit: int = 10,
+    offset: int = 0,
+    with_abstracts: bool = False,
+    save_path: str | None = None,
+    save_format: str = "json",         # "text", "json", "bibtex"
+) -> str   # JSON
+```
+
+Full-text search. Returns `{query, total, returned, elapsed_ms, works[]}`.
+Each work: `{doi, title, authors, year, journal}` (+ `abstract` if requested).
+
+### `search_by_doi`
+
+```
+search_by_doi(
+    doi: str,
+    as_citation: bool = False,
+    save_path: str | None = None,
+    save_format: str = "json",
+) -> str   # JSON or APA citation string
+```
+
+Full metadata for a single DOI. Returns `Work.to_dict()` as JSON, or APA
+citation string if `as_citation=True`.
+
+### `status`
+
+```
+status() -> str   # JSON
+```
+
+Returns `{mode, status, db_path, works, fts_indexed, citations}`.
+
+### `enrich_dois`
+
+```
+enrich_dois(dois: list[str]) -> str   # JSON
+```
+
+Fetch full metadata for a list of DOIs.
+Returns `{requested, found, works[]}` with complete Work dicts.
+
+### `check_citations`
+
+```
+check_citations(
+    identifiers: list[str],
+    validate_metadata: bool = True,
+    suggest_enrichment: bool = True,
+) -> str   # JSON
+```
+
+Validate DOIs. Returns `{summary: {total, found, missing, with_issues}, entries[]}`.
+
+### `check_bibtex_file`
+
+```
+check_bibtex_file(
+    file_path: str,               # absolute path
+    validate_metadata: bool = True,
+    suggest_enrichment: bool = True,
+) -> str   # JSON
+```
+
+### Cache Tools
+
+| Tool | Signature summary |
+|------|-------------------|
+| `cache_create` | `(name, query, limit=1000) -> JSON` |
+| `cache_query` | `(name, fields=None, include_abstract=False, ..., year_min, year_max, journal, limit) -> JSON` |
+| `cache_stats` | `(name) -> JSON` |
+| `cache_list` | `() -> JSON` |
+| `cache_top_cited` | `(name, n=20, year_min=None, year_max=None) -> JSON` |
+| `cache_citation_summary` | `(name) -> JSON` |
+| `cache_plot_scatter` | `(name, output, top_n=10) -> JSON` |
+| `cache_plot_network` | `(name, output, max_nodes=100) -> JSON` |
+| `cache_export` | `(name, output_path, format="json", fields=None) -> JSON` |
+
+## Transport Options
+
+| Transport | Use case | Command |
+|-----------|----------|---------|
+| `stdio` | Claude Desktop / Claude Code local | `crossref-local mcp start` |
+| `http` | Remote server, persistent | `crossref-local mcp start -t http --host 0.0.0.0 --port 8082` |
+| `sse` | (deprecated as of MCP spec 2025-03-26) | `crossref-local mcp start -t sse` |
+
+## Client Configuration
+
+### Local (stdio) — Claude Desktop / Claude Code
+
+```json
+{
+  "mcpServers": {
+    "crossref-local": {
+      "command": "crossref-local",
+      "args": ["mcp", "start"],
+      "env": {
+        "CROSSREF_LOCAL_DB": "/path/to/crossref.db"
+      }
+    }
+  }
+}
+```
+
+### Remote (HTTP)
+
+Server side:
+```bash
+crossref-local mcp start -t http --host 0.0.0.0 --port 8082
+```
+
+Client config:
+```json
+{
+  "mcpServers": {
+    "crossref-remote": {
+      "url": "http://your-server:8082/mcp"
+    }
+  }
+}
+```
+
+## Diagnostics
+
+```bash
+crossref-local mcp doctor         # checks fastmcp install + DB access
+crossref-local mcp installation   # prints client config templates
+crossref-local mcp list-tools     # all tool names
+crossref-local mcp list-tools -v  # with signatures
+crossref-local mcp list-tools -vv # with signatures + descriptions
+```
+
+## Typical MCP Workflow
+
+```
+1. search("epilepsy seizure prediction", limit=20)
+   -> get DOIs and basic metadata
+
+2. enrich_dois([doi1, doi2, ...])
+   -> get citation_count, references, full metadata
+
+3. cache_create("epilepsy", "epilepsy seizure prediction", limit=500)
+   -> build persistent topic cache
+
+4. cache_query("epilepsy", year_min=2020, include_citations=True, limit=50)
+   -> filtered results for analysis
+
+5. cache_plot_scatter("epilepsy", "scatter.png")
+   -> year vs citations visualization
+```

--- a/src/crossref_local/_skills/crossref-local/SKILL.md
+++ b/src/crossref_local/_skills/crossref-local/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: crossref-local
+description: Local CrossRef database with 167M+ works and full-text search. Use when resolving DOIs, searching publications, enriching bibliographies, checking citations, or calculating impact factors.
+allowed-tools: mcp__scitex__crossref_*
+---
+
+# Local CrossRef with crossref-local
+
+Local CrossRef database with 167M+ works and full-text search via FTS5.
+Search publications in milliseconds, resolve DOIs, enrich bibliographies,
+check citations, and calculate impact factors.
+
+- For quick start and output formats, see [quick-start.md](quick-start.md)
+- For common workflows (search, citations, validation, impact factors), see [workflows.md](workflows.md)
+- For CLI commands, see [cli-reference.md](cli-reference.md)
+- For MCP tools (AI agents), see [mcp-tools.md](mcp-tools.md)
+- For performance benchmarks, see [performance.md](performance.md)

--- a/src/crossref_local/_skills/crossref-local/cli-reference.md
+++ b/src/crossref_local/_skills/crossref-local/cli-reference.md
@@ -1,0 +1,35 @@
+# CLI Commands
+
+```bash
+# Search
+crossref-local search "deep learning EEG" -n 20
+crossref-local search "CRISPR" -n 5 -a --json      # With abstracts, JSON output
+crossref-local search-by-doi 10.1038/nature12373
+
+# Check citations
+crossref-local check bibliography.bib
+crossref-local check dois.txt --json
+
+# Status
+crossref-local status
+crossref-local status --json
+
+# Server
+crossref-local relay --dry-run            # Preview server config
+crossref-local relay --port 8080          # Start HTTP relay
+
+# MCP server
+crossref-local mcp start                  # stdio (Claude Desktop)
+crossref-local mcp start -t http          # HTTP transport
+crossref-local mcp doctor                 # Diagnose setup
+crossref-local mcp list-tools -vv         # List tools with descriptions
+
+# Browse API
+crossref-local list-python-apis -v        # List all public APIs
+
+# Documentation & Skills
+crossref-local docs list
+crossref-local docs get quickstart
+crossref-local skills list
+crossref-local skills get
+```

--- a/src/crossref_local/_skills/crossref-local/mcp-tools.md
+++ b/src/crossref_local/_skills/crossref-local/mcp-tools.md
@@ -1,0 +1,19 @@
+# MCP Tools (for AI agents)
+
+| Tool | Purpose |
+|------|---------|
+| `crossref_search` | Full-text search across 167M+ works |
+| `crossref_search_by_doi` | Get work by DOI |
+| `crossref_enrich_dois` | Enrich DOIs with citation counts and references |
+| `crossref_check_bibtex_file` | Validate BibTeX file against database |
+| `crossref_check_citations` | Check citation accuracy |
+| `crossref_status` | Database statistics and configuration |
+| `crossref_cache_create` | Create search cache/project |
+| `crossref_cache_query` | Query within cache |
+| `crossref_cache_export` | Export cache results (BibTeX, JSON, CSV) |
+| `crossref_cache_list` | List caches |
+| `crossref_cache_stats` | Cache statistics |
+| `crossref_cache_top_cited` | Top cited papers in cache |
+| `crossref_cache_citation_summary` | Citation summary for cache |
+| `crossref_cache_plot_scatter` | Plot citation scatter diagram |
+| `crossref_cache_plot_network` | Plot citation network graph |

--- a/src/crossref_local/_skills/crossref-local/performance.md
+++ b/src/crossref_local/_skills/crossref-local/performance.md
@@ -1,0 +1,9 @@
+# Performance Reference
+
+| Query | Matches | Time |
+|-------|---------|------|
+| `hippocampal sharp wave ripples` | 541 | 22ms |
+| `machine learning` | 477,922 | 113ms |
+| `CRISPR genome editing` | 12,170 | 257ms |
+
+Searching 167M records in milliseconds via FTS5.

--- a/src/crossref_local/_skills/crossref-local/quick-start.md
+++ b/src/crossref_local/_skills/crossref-local/quick-start.md
@@ -1,0 +1,28 @@
+# Quick Start
+
+```python
+from crossref_local import search, get, count
+
+# Full-text search (22ms for 541 matches across 167M records)
+results = search("hippocampal sharp wave ripples")
+for work in results:
+    print(f"{work.title} ({work.year})")
+
+# Get by DOI
+work = get("10.1126/science.aax0758")
+print(work.citation())
+
+# Count matches
+n = count("machine learning")  # 477,922 matches
+```
+
+## Output Formats
+
+Every search returns `Work` objects with consistent attributes:
+
+```python
+work = get("10.1038/nature12373")
+# Attributes: doi, title, year, authors, journal, abstract,
+#             citation_count, references, type, member
+work.citation()  # Formatted citation string
+```

--- a/src/crossref_local/_skills/crossref-local/workflows.md
+++ b/src/crossref_local/_skills/crossref-local/workflows.md
@@ -1,0 +1,77 @@
+# Common Workflows
+
+## "I need to find papers on a topic"
+
+```python
+from crossref_local import search
+
+results = search("CRISPR genome editing", limit=20)
+for work in results:
+    print(f"{work.title} ({work.year}) - {work.doi}")
+```
+
+## "I have DOIs and need metadata"
+
+```python
+from crossref_local import get, get_many, enrich_dois
+
+# Single DOI
+work = get("10.1038/nature12373")
+
+# Multiple DOIs
+works = get_many(["10.1038/nature12373", "10.1126/science.aax0758"])
+
+# Enrich with citation counts and references
+enriched = enrich_dois(["10.1038/nature12373"])
+```
+
+## "I need citation information"
+
+```python
+from crossref_local import get_citing, get_cited, get_citation_count
+
+citing = get_citing("10.1038/nature12373")   # Papers citing this work
+cited = get_cited("10.1038/nature12373")     # Papers this work cites
+count = get_citation_count("10.1038/nature12373")  # 1539
+```
+
+## "I want to validate my bibliography"
+
+```python
+from crossref_local import check_bibtex, check_citations
+
+# Check a BibTeX file
+report = check_bibtex("references.bib")
+
+# Check DOIs in a list
+report = check_doi_list("dois.txt")
+```
+
+## "I need a citation network visualization"
+
+```python
+from crossref_local import CitationNetwork
+
+network = CitationNetwork("10.1038/nature12373", depth=2)
+network.save_html("citation_network.html")  # requires: pip install crossref-local[viz]
+```
+
+## "I want to calculate impact factors"
+
+```python
+from crossref_local.impact_factor import ImpactFactorCalculator
+
+with ImpactFactorCalculator() as calc:
+    result = calc.calculate_impact_factor("Nature", target_year=2023)
+    print(f"IF: {result['impact_factor']:.3f}")  # 54.067
+```
+
+## "I need async operations"
+
+```python
+from crossref_local import aio
+
+async def main():
+    counts = await aio.count_many(["CRISPR", "neural network", "climate"])
+    results = await aio.search("machine learning")
+```


### PR DESCRIPTION
## Summary
- Add `_skills/<pkg>/` directory with non-monolith skills layout
- SKILL.md is index-only with links to focused sub-skill files
- Each sub-skill verified against actual source code
- pyproject.toml force-include for wheel bundling
- Real files (no symlinks)

## Test plan
- [ ] Verify `_skills/` directory exists in installed package
- [ ] Verify SKILL.md links resolve correctly
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)