### PR TITLE
fix: resolve cache and jobs dirs under pkg/runtime/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,19 @@
 legacy/
 .old/
 
+# Runtime state dirs inside .scitex/<pkg>/ — everything gitignored
+# except .gitkeep and README.md.
+.scitex/*/runtime/*
+!.scitex/*/runtime/.gitkeep
+!.scitex/*/runtime/README.md
+
+# .scitex/dev/config.yaml is tracked; everything else under .scitex/
+# is gitignored.
+.scitex/*
+!.scitex/dev/
+.scitex/dev/*
+!.scitex/dev/config.yaml
+
 # Development/Claude
 .claude/
 .dev/

--- a/src/crossref_local/_cache/utils.py
+++ b/src/crossref_local/_cache/utils.py
@@ -46,15 +46,21 @@ def sanitize_name(name: str) -> str:
 def get_cache_dir(user_id: Optional[str] = None) -> _Path:
     """Get cache directory, creating if needed.
 
+    The default location is ``$SCITEX_DIR/crossref-local/runtime/cache/``
+    (where ``$SCITEX_DIR`` defaults to ``~/.scitex``).  This may be
+    overridden via ``CROSSREF_LOCAL_CACHE_DIR``.
+
     Args:
         user_id: Optional user ID for multi-tenant scoping.
                  If provided, creates a user-specific subdirectory.
     """
-    cache_dir = _Path(
-        _os.environ.get(
-            "CROSSREF_LOCAL_CACHE_DIR", _Path.home() / ".cache" / "crossref-local"
-        )
-    )
+    env_dir = _os.environ.get("CROSSREF_LOCAL_CACHE_DIR")
+    if env_dir:
+        cache_dir = _Path(env_dir)
+    else:
+        from crossref_local._core.paths import state_dir as _state_dir
+
+        cache_dir = _state_dir("cache")
     # Add user subdirectory for multi-tenant support
     if user_id:
         # Sanitize user_id as well

--- a/src/crossref_local/jobs.py
+++ b/src/crossref_local/jobs.py
@@ -14,8 +14,9 @@ from typing import Optional as _Optional
 
 __all__ = ["create", "get", "list_jobs", "run"]
 
-# Default jobs directory
-_JOBS_DIR = _Path.home() / ".crossref_local" / "jobs"
+# Default jobs directory — resolved lazily via the runtime state-dir resolver.
+# Legacy location was ~/.crossref_local/jobs.
+_JOBS_DIR = None  # set on first use in _get_default_jobs_dir()
 
 
 @_dataclass
@@ -61,11 +62,21 @@ class Job:
         return cls(**data)
 
 
+def _get_default_jobs_dir() -> _Path:
+    """Resolve the default jobs directory under ``runtime/jobs/``."""
+    global _JOBS_DIR
+    if _JOBS_DIR is None:
+        from crossref_local._core.paths import runtime_dir as _runtime_dir
+
+        _JOBS_DIR = _runtime_dir() / "jobs"
+    return _JOBS_DIR
+
+
 class JobQueue:
     """Manages job persistence and execution."""
 
     def __init__(self, jobs_dir: _Optional[_Path] = None):
-        self.jobs_dir = _Path(jobs_dir) if jobs_dir else _JOBS_DIR
+        self.jobs_dir = _Path(jobs_dir) if jobs_dir else _get_default_jobs_dir()
         self.jobs_dir.mkdir(parents=True, exist_ok=True)
 
     def _job_path(self, job_id: str) -> _Path:


### PR DESCRIPTION
Brings crossref-local into compliance with the local-state-directories ecosystem rule (Section 4b).

- **_cache/utils.get_cache_dir()** — default now resolves to $SCITEX_DIR/crossref-local/runtime/cache/ instead of ~/.cache/crossref-local (forbidden location).
- **jobs._JOBS_DIR** — default now resolves lazily to $SCITEX_DIR/crossref-local/runtime/jobs/ instead of ~/.crossref_local/jobs (forbidden location).
- **.gitignore** — adds .scitex/*/runtime/* negation rules so regenerable runtime data never accidentally enters git, plus .scitex/dev/ negation for the tracked audit config.

Both paths honour $SCITEX_DIR, existing env-var overrides (CROSSREF_LOCAL_CACHE_DIR / explicit jobs_dir=), and lazy mkdir via the paths resolver.