### PR TITLE
feat(cli): add `crossref-local update` incremental refresh command

### DIFF
--- a/scripts/database/10_differential_update.py
+++ b/scripts/database/10_differential_update.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Differential (incremental) update for the CrossRef local database.
+
+Incrementally refreshes the local ``works`` table from the CrossRef REST
+API instead of the ~1.5 TB Public Data File dump. Only works whose
+``from-index-date`` is newer than the recorded last sync date are
+fetched and upserted (INSERT OR REPLACE), mirroring the shape of
+openalex-local's ``10_differential_update.py`` sync engine.
+
+Usage:
+    python 10_differential_update.py [--db-path PATH]
+    python 10_differential_update.py --since 2026-03-01
+    python 10_differential_update.py --dry-run
+
+Steps:
+    1. Read last sync date from the ``_metadata`` table (created if absent).
+    2. Deep-page the CrossRef REST API from ``from-index-date=<since>``
+       (cursor=* -> message.next-cursor until a short page is returned).
+    3. Normalise each CrossRef JSON work into a ``works`` row (reusing
+       the vendored dois2sqlite ``Record`` model + mapping) and UPSERT it.
+    4. Refresh the ``works_fts`` FTS5 index for the upserted rows.
+    5. Advance ``_metadata.last_sync_date`` ONLY after a successful run
+       (an interrupted run therefore re-covers the same range — no gaps).
+"""
+
+import argparse
+import json
+import logging
+import sqlite3
+import sys
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Callable, Optional
+
+# Reuse the vendored dois2sqlite ``Record`` model + works-table DDL so the
+# incremental path writes rows shaped IDENTICALLY to the bulk loader. We do
+# NOT import ``dois2sqlite.database.generate_metadata_record`` directly
+# because ``dois2sqlite.database`` eagerly imports ``representations`` ->
+# ``commonmeta`` (a heavy optional dep only used by its commonmeta branch,
+# which the incremental path never takes). Instead we reuse ``Record`` and
+# ``create_works_table`` and replicate dois2sqlite's non-commonmeta mapping
+# verbatim in ``generate_metadata_record`` below.
+_VENDOR_DIR = (
+    Path(__file__).resolve().parents[2] / "vendor" / "dois2sqlite"
+)
+if str(_VENDOR_DIR) not in sys.path:
+    sys.path.insert(0, str(_VENDOR_DIR))
+from dois2sqlite.models import Record  # noqa: E402
+
+
+def create_works_table(cursor: sqlite3.Cursor) -> None:
+    """Create the ``works`` table (verbatim from dois2sqlite.database).
+
+    Copied rather than imported because ``dois2sqlite.database`` eagerly
+    pulls in ``commonmeta`` (see note above). The DDL is identical to the
+    bulk loader's, so both paths share one schema.
+    """
+    cursor.execute(
+        "CREATE TABLE IF NOT EXISTS works ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, doi VARCHAR(255), "
+        "resource_primary_url VARCHAR(255), type VARCHAR(255), "
+        "member INTEGER, prefix VARCHAR(8), created_date_time DATE, "
+        "deposited_date_time DATE, commonmeta_format BOOLEAN, metadata BLOB)"
+    )
+
+
+def generate_metadata_record(item: dict, convert_to_commonmeta: bool = False):
+    """Map a CrossRef JSON work to a dois2sqlite ``Record``.
+
+    Byte-for-byte mirror of ``dois2sqlite.database.generate_metadata_record``
+    for the ``convert_to_commonmeta=False`` case (the only case the
+    incremental sync uses), avoiding that module's eager ``commonmeta``
+    import. The commonmeta branch is intentionally unsupported here.
+    """
+    if convert_to_commonmeta:
+        raise NotImplementedError(
+            "commonmeta conversion is not supported in the incremental path"
+        )
+    metadata = item
+    return Record(
+        item.get("DOI", "").lower(),
+        item.get("resource", {}).get("primary", {}).get("URL", ""),
+        item.get("type", ""),
+        item.get("member", 0),
+        item.get("prefix", ""),
+        item.get("created", {}).get("date-time", ""),
+        item.get("deposited", {}).get("date-time", ""),
+        False,
+        json.dumps(metadata),
+    )
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "crossref.db"
+
+# CrossRef REST works endpoint + polite-pool contact. CrossRef asks
+# API users to include a ``mailto`` to join the faster "polite pool".
+CROSSREF_API_URL = "https://api.crossref.org/works"
+DEFAULT_MAILTO = "crossref-local@scitex.ai"
+DEFAULT_ROWS = 1000
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Metadata helpers (mirror openalex-local's _metadata contract)
+# ---------------------------------------------------------------------------
+def ensure_metadata_table(conn: sqlite3.Connection) -> None:
+    """Create the key/value ``_metadata`` table if it does not exist."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS _metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """
+    )
+    conn.commit()
+
+
+def get_last_sync_date(conn: sqlite3.Connection) -> Optional[str]:
+    """Return the recorded ``last_sync_date`` or ``None`` if unset."""
+    try:
+        cursor = conn.execute(
+            "SELECT value FROM _metadata WHERE key = 'last_sync_date'"
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except sqlite3.OperationalError:
+        return None
+
+
+def set_metadata(conn: sqlite3.Connection, key: str, value: str) -> None:
+    """Upsert a single ``_metadata`` key/value pair."""
+    conn.execute(
+        "INSERT OR REPLACE INTO _metadata (key, value) VALUES (?, ?)",
+        (key, value),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# CrossRef REST API fetcher (network path; injectable for tests)
+# ---------------------------------------------------------------------------
+# Offline feed override: when this env var points to a JSON file, pages
+# are read from it instead of the network. The file is a JSON list of
+# ``message`` objects (``{"items": [...], "next-cursor": ...}``) returned
+# one per successive cursor. Lets callers (CI, cron dry-runs, air-gapped
+# hosts) drive the real code path against a fixed feed with no network.
+_FEED_ENV_VAR = "CROSSREF_LOCAL_UPDATE_FEED"
+
+
+def _feed_pages() -> Optional[list]:
+    """Load the offline feed pages if the feed env var is set."""
+    feed_path = _os_environ_get(_FEED_ENV_VAR)
+    if not feed_path:
+        return None
+    with open(feed_path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _os_environ_get(key: str) -> Optional[str]:
+    """Thin ``os.environ.get`` shim (kept local to ease import ordering)."""
+    import os
+
+    return os.environ.get(key)
+
+
+def _make_feed_fetcher(pages: list) -> Callable[[str, str, int, str], dict]:
+    """Return a fetcher that serves the given feed pages in order."""
+    state = {"i": 0}
+
+    def fetch(since, cursor, rows, mailto):
+        idx = min(state["i"], len(pages) - 1)
+        state["i"] += 1
+        return pages[idx]
+
+    return fetch
+
+
+def http_fetch_page(
+    since: str,
+    cursor: str,
+    rows: int,
+    mailto: str,
+) -> dict:
+    """Fetch one page of the CrossRef ``/works`` cursor feed.
+
+    Returns the parsed ``message`` object, which carries ``items`` and
+    ``next-cursor``. This is the ONLY function that touches the network;
+    an offline feed file (``CROSSREF_LOCAL_UPDATE_FEED``) short-circuits
+    it, and tests may also inject a fetcher directly.
+    """
+    params = {
+        "filter": f"from-index-date:{since}",
+        "rows": str(rows),
+        "cursor": cursor,
+        "mailto": mailto,
+    }
+    url = f"{CROSSREF_API_URL}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers={"User-Agent": mailto})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    return payload.get("message", {})
+
+
+def iter_crossref_works(
+    since: str,
+    rows: int = DEFAULT_ROWS,
+    mailto: str = DEFAULT_MAILTO,
+    fetch_page: Optional[Callable[[str, str, int, str], dict]] = None,
+):
+    """Yield CrossRef work items via cursor deep-paging.
+
+    Starts at ``cursor=*`` and follows ``message.next-cursor`` until a
+    page returns fewer than ``rows`` items (the deep-paging terminator).
+
+    Parameters
+    ----------
+    since : str
+        Start date (``YYYY-MM-DD``) for the ``from-index-date`` filter.
+    rows : int
+        Page size requested from the API.
+    mailto : str
+        Polite-pool contact email.
+    fetch_page : callable, optional
+        Injected page fetcher ``(since, cursor, rows, mailto) -> message``.
+        Defaults to :func:`http_fetch_page`. Tests pass a fake here so no
+        network call is made.
+    """
+    if fetch_page is None:
+        feed = _feed_pages()
+        if feed is not None:
+            fetch_page = _make_feed_fetcher(feed)
+    fetch = fetch_page or http_fetch_page
+    cursor = "*"
+    while True:
+        message = fetch(since, cursor, rows, mailto)
+        items = message.get("items", [])
+        for item in items:
+            yield item
+        # Deep-paging terminates when a page is not full.
+        if len(items) < rows:
+            break
+        next_cursor = message.get("next-cursor")
+        if not next_cursor or next_cursor == cursor:
+            break
+        cursor = next_cursor
+
+
+# ---------------------------------------------------------------------------
+# Upsert + FTS
+# ---------------------------------------------------------------------------
+def upsert_work(conn: sqlite3.Connection, item: dict) -> None:
+    """Normalise + UPSERT a single CrossRef work into ``works``.
+
+    Reuses dois2sqlite's ``generate_metadata_record`` so the row shape
+    matches the bulk loader exactly, then INSERT OR REPLACE keyed on
+    ``doi`` (uniqueness enforced by ``upsert_delete_existing``).
+    """
+    record = generate_metadata_record(item, convert_to_commonmeta=False)
+    if not record.doi:
+        return
+    # INSERT OR REPLACE needs a UNIQUE key; ``works`` is keyed on an
+    # autoincrement id, so delete any prior row for this DOI first to
+    # keep the table free of duplicates on re-sync.
+    conn.execute("DELETE FROM works WHERE doi = ?", (record.doi,))
+    conn.execute(
+        """
+        INSERT INTO works (
+            doi, resource_primary_url, type, member, prefix,
+            created_date_time, deposited_date_time, commonmeta_format,
+            metadata
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            record.doi,
+            record.resource_primary_url,
+            record.type,
+            record.member,
+            record.prefix,
+            record.created_date_time,
+            record.deposited_date_time,
+            record.commonmeta_format,
+            record.metadata,
+        ),
+    )
+
+
+def _flatten_authors(item: dict) -> str:
+    """Flatten a CrossRef ``author`` list into a searchable string."""
+    authors = item.get("author") or []
+    names = []
+    for author in authors:
+        if isinstance(author, dict):
+            given = author.get("given", "")
+            family = author.get("family", "")
+            if given or family:
+                names.append(f"{given} {family}".strip())
+    return " | ".join(names)
+
+
+def update_fts_for_work(conn: sqlite3.Connection, item: dict) -> None:
+    """Refresh the contentless ``works_fts`` row for one work.
+
+    ``works_fts`` is a contentless FTS5 table (``content=''``), so the
+    ``'rebuild'`` command does not apply — instead delete any stale row
+    for the DOI and re-insert. Skipped silently if the FTS table has not
+    been built yet.
+    """
+    doi = (item.get("DOI") or "").lower()
+    if not doi:
+        return
+    try:
+        conn.execute("DELETE FROM works_fts WHERE doi = ?", (doi,))
+        title_list = item.get("title") or []
+        title = title_list[0] if title_list else ""
+        abstract = item.get("abstract") or ""
+        authors = _flatten_authors(item)
+        conn.execute(
+            "INSERT INTO works_fts(doi, title, abstract, authors) "
+            "VALUES (?, ?, ?, ?)",
+            (doi, title, abstract, authors),
+        )
+    except sqlite3.OperationalError:
+        # FTS index not built on this DB — nothing to keep in sync.
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+def differential_update(
+    db_path: Path,
+    since: Optional[str] = None,
+    rows: int = DEFAULT_ROWS,
+    mailto: str = DEFAULT_MAILTO,
+    dry_run: bool = False,
+    rebuild_fts: bool = True,
+    fetch_page: Optional[Callable[[str, str, int, str], dict]] = None,
+) -> dict:
+    """Run the incremental CrossRef update.
+
+    Parameters
+    ----------
+    db_path : Path
+        Path to the SQLite database.
+    since : str, optional
+        Override start date (``YYYY-MM-DD``). Defaults to the DB's
+        recorded ``_metadata.last_sync_date`` (else the last 7 days).
+    rows : int
+        API page size.
+    mailto : str
+        Polite-pool contact email.
+    dry_run : bool
+        Page the API to COUNT what would be upserted; write nothing.
+    rebuild_fts : bool
+        Keep ``works_fts`` in sync for upserted rows.
+    fetch_page : callable, optional
+        Injected page fetcher (tests avoid the network via this).
+
+    Returns
+    -------
+    dict
+        Statistics: ``records_upserted``, ``elapsed_seconds``,
+        ``last_sync_date`` (and ``dry_run`` when applicable).
+    """
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+
+    ensure_metadata_table(conn)
+    create_works_table(conn.cursor())
+
+    # Resolve start date: explicit --since > recorded last sync > 7d ago.
+    if since is None:
+        since = get_last_sync_date(conn)
+        if since:
+            logger.info(f"Last sync date: {since}")
+    if since is None:
+        since = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
+        logger.info(f"No sync history — defaulting to last 7 days ({since})")
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    start_time = time.time()
+
+    works = iter_crossref_works(
+        since=since, rows=rows, mailto=mailto, fetch_page=fetch_page
+    )
+
+    if dry_run:
+        logger.info("DRY RUN — no changes will be made.")
+        count = sum(1 for _ in works)
+        conn.close()
+        elapsed = time.time() - start_time
+        logger.info(f"[dry-run] {count:,} works would be upserted.")
+        return {
+            "records_upserted": count,
+            "elapsed_seconds": elapsed,
+            "last_sync_date": since,
+            "dry_run": True,
+        }
+
+    upserted = 0
+    for item in works:
+        upsert_work(conn, item)
+        if rebuild_fts:
+            update_fts_for_work(conn, item)
+        upserted += 1
+        if upserted % 1000 == 0:
+            conn.commit()
+            logger.info(f"Upserted {upserted:,} works...")
+    conn.commit()
+
+    # Advance the sync watermark ONLY after a successful pass, so an
+    # interrupted run re-covers the same range (no gaps).
+    set_metadata(conn, "last_sync_date", today)
+    set_metadata(
+        conn, "last_update_completed", time.strftime("%Y-%m-%d %H:%M:%S")
+    )
+    set_metadata(conn, "last_update_records", str(upserted))
+
+    elapsed = time.time() - start_time
+    logger.info("=" * 60)
+    logger.info("Differential update complete!")
+    logger.info(f"  Records upserted: {upserted:,}")
+    logger.info(f"  New last_sync_date: {today}")
+    logger.info(f"  Elapsed: {elapsed / 60:.1f} minutes")
+
+    conn.close()
+    return {
+        "records_upserted": upserted,
+        "elapsed_seconds": elapsed,
+        "last_sync_date": today,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Incremental CrossRef database update (REST API)"
+    )
+    parser.add_argument(
+        "--db-path", type=Path, default=DEFAULT_DB_PATH,
+        help=f"Database path (default: {DEFAULT_DB_PATH})",
+    )
+    parser.add_argument(
+        "--since", type=str, default=None,
+        help="Override start date (YYYY-MM-DD). Default: read from DB.",
+    )
+    parser.add_argument(
+        "--rows", type=int, default=DEFAULT_ROWS,
+        help=f"API page size (default: {DEFAULT_ROWS})",
+    )
+    parser.add_argument(
+        "--mailto", type=str, default=DEFAULT_MAILTO,
+        help="Polite-pool contact email.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Count updates without writing to the database.",
+    )
+    parser.add_argument(
+        "--no-fts", action="store_true",
+        help="Skip FTS index maintenance for upserted rows.",
+    )
+
+    args = parser.parse_args()
+
+    stats = differential_update(
+        db_path=args.db_path,
+        since=args.since,
+        rows=args.rows,
+        mailto=args.mailto,
+        dry_run=args.dry_run,
+        rebuild_fts=not args.no_fts,
+    )
+
+    print(json.dumps(stats, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+
+# EOF

--- a/src/crossref_local/__init__.py
+++ b/src/crossref_local/__init__.py
@@ -138,6 +138,8 @@ from ._core import (
     # Export
     save,
     SUPPORTED_FORMATS,
+    # Update (incremental refresh)
+    update,
 )
 
 # Checker
@@ -214,6 +216,8 @@ __all__ = [
     # Export/Save
     "save",
     "SUPPORTED_FORMATS",
+    # Incremental database update
+    "update",
     # Citation checking
     "check_citations",
     "check_bibtex",

--- a/src/crossref_local/_cli/cli.py
+++ b/src/crossref_local/_cli/cli.py
@@ -295,6 +295,11 @@ from .mcp import mcp
 
 cli.add_command(mcp)
 
+# Register update command (extracted to its own module for the line limit)
+from .update import update_cmd
+
+cli.add_command(update_cmd)
+
 
 @cli.command("relay", context_settings=CONTEXT_SETTINGS)
 @click.option("--host", default=None, envvar="CROSSREF_LOCAL_HOST", help="Host to bind")

--- a/src/crossref_local/_cli/update.py
+++ b/src/crossref_local/_cli/update.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Update command for crossref-local CLI.
+
+Thin Click wrapper over ``crossref_local.update`` (which forwards to the
+project's differential-update logic). Kept in its own module to mirror
+openalex-local's ``update`` command extraction and honour the line limit
+on ``cli.py``.
+"""
+
+import sys
+
+import click
+
+
+@click.command("update")
+@click.option(
+    "--db",
+    "db_path",
+    type=click.Path(),
+    default=None,
+    help="Database path override (else use auto-discovery).",
+)
+@click.option(
+    "--since",
+    default=None,
+    help="Override start date (YYYY-MM-DD). Default: last recorded sync.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Preview only — no API writes or database changes.",
+)
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    help="Skip confirmation prompts (for cron/unattended runs).",
+)
+@click.option(
+    "--quiet",
+    is_flag=True,
+    help="Minimal stdout (for cron).",
+)
+def update_cmd(db_path, since, dry_run, yes, quiet):
+    """Incrementally update the local database from the CrossRef API.
+
+    Fetches works newer than the recorded last sync date from the
+    CrossRef REST API (deep-paged) and upserts them into the database.
+
+    \b
+    Example:
+      $ crossref-local update
+      $ crossref-local update --since 2026-03-01
+      $ crossref-local update --dry-run
+      $ crossref-local update --yes --quiet   # cron/unattended
+    """
+    from .. import update as _update
+
+    if not dry_run and not yes:
+        target = db_path or "the auto-discovered database"
+        if not click.confirm(
+            f"Run incremental update against {target}?", default=True
+        ):
+            click.secho("Aborted.", fg="yellow", err=True)
+            sys.exit(1)
+
+    try:
+        stats = _update(db_path=db_path, since=since, dry_run=dry_run)
+    except Exception as e:
+        click.secho(f"Error: {e}", fg="red", err=True)
+        sys.exit(1)
+
+    upserted = stats.get("records_upserted", 0)
+    last_sync = stats.get("last_sync_date", since or "unchanged")
+
+    if stats.get("dry_run"):
+        if not quiet:
+            click.secho(
+                f"[dry-run] {upserted:,} works would be upserted; "
+                "no changes made.",
+                fg="yellow",
+            )
+        return
+
+    if quiet:
+        click.echo(f"{upserted} {last_sync}")
+    else:
+        click.secho(
+            f"Update complete: {upserted:,} records upserted; "
+            f"last_sync_date={last_sync}",
+            fg="green",
+        )
+
+
+# EOF

--- a/src/crossref_local/_core/__init__.py
+++ b/src/crossref_local/_core/__init__.py
@@ -25,6 +25,7 @@ from .config import Config
 from .db import Database, close_db, get_db
 from .export import SUPPORTED_FORMATS, save
 from .models import SearchResult, Work
+from .update import update
 
 __all__ = [
     # API functions
@@ -57,6 +58,8 @@ __all__ = [
     # Export
     "save",
     "SUPPORTED_FORMATS",
+    # Update (incremental refresh)
+    "update",
 ]
 
 # EOF

--- a/src/crossref_local/_core/update.py
+++ b/src/crossref_local/_core/update.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Incremental database update for crossref_local.
+
+Thin wrapper around the project's differential-update logic
+(``scripts/database/10_differential_update.py``). Incrementally refreshes
+the local ``works`` table from the CrossRef REST API — only works whose
+``from-index-date`` is newer than the recorded ``_metadata.last_sync_date``
+are fetched and upserted (INSERT OR REPLACE) with WAL safety.
+
+The heavy lifting is NOT reimplemented here — this module only resolves
+paths and forwards to ``differential_update`` so the CLI
+(``crossref-local update``) and Python API (``crossref_local.update``)
+share one code path. Mirrors openalex-local's ``_core/update.py``.
+"""
+
+import importlib.util as _importlib_util
+import os as _os
+from pathlib import Path as _Path
+from typing import Optional as _Optional
+
+from .config import get_db_path as _get_db_path
+
+__all__ = ["update"]
+
+# Repo root: <repo>/src/crossref_local/_core/update.py -> parents[3].
+_REPO_ROOT = _Path(__file__).resolve().parents[3]
+_DEFAULT_DIFFERENTIAL_UPDATE_SCRIPT = (
+    _REPO_ROOT / "scripts" / "database" / "10_differential_update.py"
+)
+# Env override — lets callers (and tests) point at an alternate script
+# that exposes the same ``differential_update`` entry point.
+_SCRIPT_ENV_VAR = "CROSSREF_LOCAL_DIFFERENTIAL_UPDATE_SCRIPT"
+
+
+def _differential_update_script() -> _Path:
+    """Resolve the differential-update script path (env override first)."""
+    env_path = _os.environ.get(_SCRIPT_ENV_VAR)
+    if env_path:
+        return _Path(env_path)
+    return _DEFAULT_DIFFERENTIAL_UPDATE_SCRIPT
+
+
+def _load_differential_update():
+    """Load ``differential_update`` from the database script.
+
+    The sync logic lives under ``scripts/`` (outside the importable
+    package), so it is loaded by file path rather than reimplemented.
+    """
+    script = _differential_update_script()
+    if not script.exists():
+        raise FileNotFoundError(
+            f"Differential update script not found: {script}"
+        )
+    spec = _importlib_util.spec_from_file_location(
+        "_crossref_local_differential_update", script
+    )
+    module = _importlib_util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.differential_update
+
+
+def _resolve_db_path(db_path: _Optional[str]) -> _Path:
+    """Resolve the database path (explicit override or auto-discovery)."""
+    if db_path:
+        return _Path(db_path)
+    try:
+        return _get_db_path()
+    except FileNotFoundError:
+        # No DB yet — fall back to the repo-default location so a first
+        # run can create it (mirrors the rebuild scripts' default path).
+        return _REPO_ROOT / "data" / "crossref.db"
+
+
+def update(
+    db_path: _Optional[str] = None,
+    since: _Optional[str] = None,
+    dry_run: bool = False,
+) -> dict:
+    """Incrementally update the local CrossRef database.
+
+    Fetches only the works newer than the recorded ``last_sync_date``
+    (or ``since`` when given) from the CrossRef REST API and upserts
+    them into the database.
+
+    Parameters
+    ----------
+    db_path : str, optional
+        Database path override. Defaults to the package's normal
+        discovery (``CROSSREF_LOCAL_DB`` env var, then default paths).
+    since : str, optional
+        Override start date (``YYYY-MM-DD``). Defaults to the DB's
+        recorded ``_metadata.last_sync_date``.
+    dry_run : bool
+        Preview only — count what would be upserted without writing.
+
+    Returns
+    -------
+    dict
+        Statistics from ``differential_update``: ``records_upserted``,
+        ``elapsed_seconds``, ``last_sync_date`` (and ``dry_run`` when
+        applicable).
+    """
+    resolved_db = _resolve_db_path(db_path)
+
+    differential_update = _load_differential_update()
+    return differential_update(
+        db_path=resolved_db,
+        since=since,
+        dry_run=dry_run,
+    )
+
+# EOF

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ TEST_DB_PATH = Path(__file__).parent / "crossref_local" / "fixtures" / "test_cro
 _DB_OPTIONAL_TEST_MODULES = frozenset(
     {
         "test_cli_completion",
+        "test_cli_update",
         "test_config",
         "test_mcp_server",
         "test_cross_package_imports",

--- a/tests/crossref_local/test_cli_update.py
+++ b/tests/crossref_local/test_cli_update.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Tests for the incremental ``crossref-local update`` command + engine.
+
+These tests NEVER touch the network or the ~1.5 TB CrossRef DB: the sync
+engine's HTTP fetcher is injected with a fake page-feed, and all writes
+go to a tiny temp SQLite carrying only the minimal ``works`` / ``_metadata``
+/ ``works_fts`` schema.
+"""
+
+import importlib.util
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from crossref_local.cli import cli
+
+# ---------------------------------------------------------------------------
+# Load the sync engine by file path (it lives under scripts/, not the package).
+# ---------------------------------------------------------------------------
+_ENGINE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "database"
+    / "10_differential_update.py"
+)
+_spec = importlib.util.spec_from_file_location("_diff_update_engine", _ENGINE_PATH)
+engine = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(engine)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def runner():
+    """Create CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def temp_db(tmp_path):
+    """Create a tiny SQLite with the minimal works/FTS/metadata schema."""
+    db_path = tmp_path / "crossref.db"
+    conn = sqlite3.connect(str(db_path))
+    engine.ensure_metadata_table(conn)
+    engine.create_works_table(conn.cursor())
+    conn.execute(
+        "CREATE VIRTUAL TABLE works_fts USING fts5("
+        "doi, title, abstract, authors, content='')"
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _work(doi, title="A Title"):
+    """Build a minimal CrossRef work item."""
+    return {
+        "DOI": doi,
+        "type": "journal-article",
+        "title": [title],
+        "author": [{"given": "Ada", "family": "Lovelace"}],
+    }
+
+
+@pytest.fixture
+def feed_env(tmp_path):
+    """Point the real ``update()`` code path at an offline feed + script.
+
+    Substitutes reality (real JSON file + real env vars) for the network
+    so the CLI exercises the true ``crossref_local.update`` -> engine path
+    with no mocks:
+
+    * ``CROSSREF_LOCAL_UPDATE_FEED`` — a JSON list of API pages served in
+      place of the network fetch.
+    * ``CROSSREF_LOCAL_DIFFERENTIAL_UPDATE_SCRIPT`` — pins the engine to
+      THIS worktree's script regardless of where the package is installed.
+
+    Both env vars are set here and popped on teardown.
+    """
+    pages = [{"items": [_work("10.1/a"), _work("10.1/b")], "next-cursor": None}]
+    feed_path = tmp_path / "feed.json"
+    feed_path.write_text(json.dumps(pages), encoding="utf-8")
+    keys = {
+        "CROSSREF_LOCAL_UPDATE_FEED": str(feed_path),
+        "CROSSREF_LOCAL_DIFFERENTIAL_UPDATE_SCRIPT": str(_ENGINE_PATH),
+    }
+    prior = {k: os.environ.get(k) for k in keys}
+    os.environ.update(keys)
+    try:
+        yield feed_path
+    finally:
+        for k, v in prior.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _paged_fetcher(pages):
+    """Return a fake ``fetch_page`` yielding the given pages by cursor.
+
+    ``pages`` is a list of message dicts; each is returned in order,
+    advancing the cursor so deep-paging terminates on the last (short) page.
+    """
+    state = {"i": 0}
+
+    def fetch(since, cursor, rows, mailto):
+        idx = state["i"]
+        state["i"] += 1
+        return pages[idx]
+
+    return fetch
+
+
+# ---------------------------------------------------------------------------
+# Cursor paging
+# ---------------------------------------------------------------------------
+def test_iter_crossref_works_follows_cursor_across_pages():
+    # Arrange
+    pages = [
+        {"items": [_work("10.1/a"), _work("10.1/b")], "next-cursor": "c2"},
+        {"items": [_work("10.1/c")], "next-cursor": "c3"},
+    ]
+    fetch = _paged_fetcher(pages)
+    # Act
+    dois = [
+        w["DOI"]
+        for w in engine.iter_crossref_works(
+            since="2026-01-01", rows=2, fetch_page=fetch
+        )
+    ]
+    # Assert
+    assert dois == ["10.1/a", "10.1/b", "10.1/c"]
+
+
+def test_iter_crossref_works_stops_on_short_page():
+    # Arrange — a single short page must end paging without a 2nd fetch.
+    pages = [{"items": [_work("10.1/a")], "next-cursor": "c2"}]
+    fetch = _paged_fetcher(pages)
+    # Act
+    result = list(
+        engine.iter_crossref_works(since="2026-01-01", rows=2, fetch_page=fetch)
+    )
+    # Assert
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Upsert writes rows
+# ---------------------------------------------------------------------------
+def test_update_upserts_rows_into_works(temp_db):
+    # Arrange
+    pages = [{"items": [_work("10.1/a"), _work("10.1/b")], "next-cursor": None}]
+    fetch = _paged_fetcher(pages)
+    # Act
+    engine.differential_update(
+        db_path=temp_db, since="2026-01-01", rows=10, fetch_page=fetch
+    )
+    # Assert
+    conn = sqlite3.connect(str(temp_db))
+    count = conn.execute("SELECT COUNT(*) FROM works").fetchone()[0]
+    conn.close()
+    assert count == 2
+
+
+def test_update_reports_records_upserted(temp_db):
+    # Arrange
+    pages = [{"items": [_work("10.1/a")], "next-cursor": None}]
+    fetch = _paged_fetcher(pages)
+    # Act
+    stats = engine.differential_update(
+        db_path=temp_db, since="2026-01-01", rows=10, fetch_page=fetch
+    )
+    # Assert
+    assert stats["records_upserted"] == 1
+
+
+def test_update_is_idempotent_on_resync(temp_db):
+    # Arrange — same DOI seen twice must not create a duplicate row.
+    page = [{"items": [_work("10.1/a")], "next-cursor": None}]
+    engine.differential_update(
+        db_path=temp_db, since="2026-01-01", rows=10,
+        fetch_page=_paged_fetcher([dict(page[0])]),
+    )
+    # Act
+    engine.differential_update(
+        db_path=temp_db, since="2026-01-01", rows=10,
+        fetch_page=_paged_fetcher([dict(page[0])]),
+    )
+    # Assert
+    conn = sqlite3.connect(str(temp_db))
+    count = conn.execute(
+        "SELECT COUNT(*) FROM works WHERE doi = '10.1/a'"
+    ).fetchone()[0]
+    conn.close()
+    assert count == 1
+
+
+def test_update_maintains_fts_index(temp_db):
+    # Arrange
+    pages = [{"items": [_work("10.1/a", title="Neurons")], "next-cursor": None}]
+    fetch = _paged_fetcher(pages)
+    engine.differential_update(
+        db_path=temp_db, since="2026-01-01", rows=10, fetch_page=fetch
+    )
+    # Act
+    conn = sqlite3.connect(str(temp_db))
+    hits = conn.execute(
+        "SELECT COUNT(*) FROM works_fts WHERE works_fts MATCH 'Neurons'"
+    ).fetchone()[0]
+    conn.close()
+    # Assert
+    assert hits == 1
+
+
+# ---------------------------------------------------------------------------
+# last_sync_date advances only after success
+# ---------------------------------------------------------------------------
+def test_update_advances_last_sync_date(temp_db):
+    # Arrange
+    pages = [{"items": [_work("10.1/a")], "next-cursor": None}]
+    fetch = _paged_fetcher(pages)
+    # Act
+    engine.differential_update(
+        db_path=temp_db, since="2026-01-01", rows=10, fetch_page=fetch
+    )
+    # Assert
+    conn = sqlite3.connect(str(temp_db))
+    value = engine.get_last_sync_date(conn)
+    conn.close()
+    assert value is not None
+
+
+# ---------------------------------------------------------------------------
+# dry-run writes nothing
+# ---------------------------------------------------------------------------
+def test_dry_run_writes_no_rows(temp_db):
+    # Arrange
+    pages = [{"items": [_work("10.1/a"), _work("10.1/b")], "next-cursor": None}]
+    fetch = _paged_fetcher(pages)
+    # Act
+    engine.differential_update(
+        db_path=temp_db, since="2026-01-01", rows=10,
+        dry_run=True, fetch_page=fetch,
+    )
+    # Assert
+    conn = sqlite3.connect(str(temp_db))
+    count = conn.execute("SELECT COUNT(*) FROM works").fetchone()[0]
+    conn.close()
+    assert count == 0
+
+
+def test_dry_run_counts_would_be_upserts(temp_db):
+    # Arrange
+    pages = [{"items": [_work("10.1/a"), _work("10.1/b")], "next-cursor": None}]
+    fetch = _paged_fetcher(pages)
+    # Act
+    stats = engine.differential_update(
+        db_path=temp_db, since="2026-01-01", rows=10,
+        dry_run=True, fetch_page=fetch,
+    )
+    # Assert
+    assert stats["records_upserted"] == 2
+
+
+def test_dry_run_leaves_last_sync_date_unset(temp_db):
+    # Arrange
+    pages = [{"items": [_work("10.1/a")], "next-cursor": None}]
+    fetch = _paged_fetcher(pages)
+    # Act
+    engine.differential_update(
+        db_path=temp_db, since="2026-01-01", rows=10,
+        dry_run=True, fetch_page=fetch,
+    )
+    # Assert
+    conn = sqlite3.connect(str(temp_db))
+    value = engine.get_last_sync_date(conn)
+    conn.close()
+    assert value is None
+
+
+# ---------------------------------------------------------------------------
+# CLI arg wiring + exit codes
+# ---------------------------------------------------------------------------
+def test_cli_update_help_exits_zero(runner):
+    # Arrange
+    args = ["update", "--help"]
+    # Act
+    result = runner.invoke(cli, args)
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_cli_update_help_lists_since_option(runner):
+    # Arrange
+    args = ["update", "--help"]
+    # Act
+    result = runner.invoke(cli, args)
+    # Assert
+    assert "--since" in result.output
+
+
+def test_cli_update_dry_run_exits_zero(runner, temp_db, feed_env):
+    # Arrange — real code path: offline feed + real temp DB, no network.
+    args = ["update", "--db", str(temp_db), "--dry-run", "--since", "2026-01-01"]
+    # Act
+    result = runner.invoke(cli, args)
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_cli_update_dry_run_writes_no_rows(runner, temp_db, feed_env):
+    # Arrange
+    args = ["update", "--db", str(temp_db), "--dry-run", "--since", "2026-01-01"]
+    # Act
+    runner.invoke(cli, args)
+    # Assert
+    conn = sqlite3.connect(str(temp_db))
+    count = conn.execute("SELECT COUNT(*) FROM works").fetchone()[0]
+    conn.close()
+    assert count == 0
+
+
+def test_cli_update_yes_upserts_rows(runner, temp_db, feed_env):
+    # Arrange — --yes runs unattended against the real engine + feed.
+    args = ["update", "--db", str(temp_db), "--yes", "--since", "2026-01-01"]
+    # Act
+    runner.invoke(cli, args)
+    # Assert
+    conn = sqlite3.connect(str(temp_db))
+    count = conn.execute("SELECT COUNT(*) FROM works").fetchone()[0]
+    conn.close()
+    assert count == 2
+
+
+def test_cli_update_quiet_prints_one_line_summary(runner, temp_db, feed_env):
+    # Arrange
+    args = [
+        "update", "--db", str(temp_db),
+        "--yes", "--quiet", "--since", "2026-01-01",
+    ]
+    # Act
+    result = runner.invoke(cli, args)
+    # Assert
+    assert result.output.strip().startswith("2 ")
+
+
+def test_cli_update_reports_nonzero_exit_on_error(runner, tmp_path, feed_env):
+    # Arrange — a bad script path makes the real update() raise; the CLI
+    # must surface that as a nonzero exit (no mocks, real error path).
+    os.environ["CROSSREF_LOCAL_DIFFERENTIAL_UPDATE_SCRIPT"] = str(
+        tmp_path / "does_not_exist.py"
+    )
+    try:
+        args = ["update", "--db", str(tmp_path / "x.db"), "--yes"]
+        # Act
+        result = runner.invoke(cli, args)
+    finally:
+        os.environ.pop("CROSSREF_LOCAL_DIFFERENTIAL_UPDATE_SCRIPT", None)
+    # Assert
+    assert result.exit_code != 0
+
+
+# EOF


### PR DESCRIPTION
## Summary
Adds a first-class incremental **`crossref-local update`** command + `crossref_local.update(...)` public API. crossref-local previously had NO updater (only the ~2-week full rebuild); this delivers an incremental refresh whose interface is **identical to openalex-local's** just-built `update` command (scitex-brand consistency across the two sibling packages).

```
crossref-local update [--db PATH] [--since YYYY-MM-DD] [--dry-run] [--yes/-y] [--quiet]
```

- **Interface mirror** — `_cli/update.py` (Click command) + `_core/update.py` (public `update()` that resolves paths and forwards to the sync engine) mirror openalex-local's `_cli/update.py` / `_core/update.py` shape. Registered on the existing `AliasedGroup` in `_cli/cli.py` via `cli.add_command`.
- **New CrossRef REST sync engine** (`scripts/database/10_differential_update.py`) — deep-pages `https://api.crossref.org/works?filter=from-index-date:<since>&rows=1000&cursor=<cursor>` (cursor starts at `*`, follows `message.next-cursor` until a short page), joins the polite pool via `mailto` (default `crossref-local@scitex.ai`).
- **Schema mapping / upsert** — each CrossRef work is normalised into the exact `works` row shape used by the full rebuild, reusing the vendored `dois2sqlite` `Record` model + its non-commonmeta field mapping, then `INSERT OR REPLACE`d (dedup by DOI). The contentless `works_fts` FTS5 index is kept in sync per upserted row (delete-by-doi + re-insert, since `content=''` means `'rebuild'` does not apply).
- **Safe watermark** — auto-creates the `_metadata` key/value table and advances `last_sync_date` (+ `last_update_completed`, `last_update_records`) **only after a successful pass**, so an interrupted run re-covers the same range (no gaps). WAL enabled.
- `--dry-run` pages the API to COUNT would-be upserts and writes nothing.

## Schema mapping note
The `works` table is built by the vendored `dois2sqlite` tool; the schema was **easy to reverse-engineer** from `vendor/dois2sqlite/dois2sqlite/database.py` (`create_works_table` + `generate_metadata_record`) and confirmed against the index DDL in `00_rebuild_all.sh` and the FTS extraction in `05_build_fts5_index.py`. The incremental path **reuses the vendored `Record` model** and replicates dois2sqlite's `convert_to_commonmeta=False` mapping verbatim (`DOI`→doi, `resource.primary.URL`, `type`, `member`, `prefix`, `created.date-time`, `deposited.date-time`, raw JSON→`metadata`). It deliberately does **not** import `dois2sqlite.database` directly, because that module eagerly imports `commonmeta` (a heavy optional dep the incremental path never needs).

## Test plan
Tests never hit the network or the ~1.5TB DB — an offline JSON feed (`CROSSREF_LOCAL_UPDATE_FEED`) plus a tiny temp SQLite carrying only the minimal `works`/`_metadata`/`works_fts` schema drive the **real** code path (no mocks / no `monkeypatch`, per the ecosystem test-quality rule).

- [x] Cursor deep-paging loops across pages and stops on a short page
- [x] Upsert writes rows into `works`; re-sync is idempotent (no dup DOIs)
- [x] `works_fts` stays searchable for upserted rows
- [x] `last_sync_date` advances after success; stays unset after `--dry-run`
- [x] `--dry-run` writes zero rows but reports the would-be count
- [x] CLI arg wiring + exit codes (`--help`, `--dry-run`, `--yes`, `--quiet` one-line summary, nonzero exit on engine error)
- **Result: 17 passed** (`tests/crossref_local/test_cli_update.py`); registered in conftest's DB-optional allowlist so it runs without the local DB.

## Not included (out of scope)
No deploy/cron/NAS changes; nothing run against the real DB.