### PR TITLE
chore: gitignore .worktrees/ (agent worktree churn)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -696,3 +696,4 @@ tests/crossref_local/fixtures/*.db
 tests/crossref_local/fixtures/*.json
 _.venv/
 .coverage
+.worktrees/


### PR DESCRIPTION
Agent worktree-isolation creates <repo>/.worktrees/, which was NOT gitignored -> perpetual dirty tree -> pre-stop rescue-autosave commits pollute develop (fleet-wide, blocked deploy-freshness ff-pull). Adds .worktrees/ to .gitignore. Operator-approved 2026-07-08 (per-repo, option B).