### PR TITLE
ci: migrate to scitex-ai/.github reusable workflows

### DIFF
--- a/.github/workflows/auto-merge-to-develop.yaml
+++ b/.github/workflows/auto-merge-to-develop.yaml
@@ -1,9 +1,9 @@
 name: auto-merge-to-develop
-# Merge green PRs that TARGET develop, the moment their checks complete.
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers/permissions preserved verbatim from the prior local file.
 # GitHub reads check_suite-triggered workflows from the DEFAULT branch (main),
-# so this file lives on main but acts ONLY on PRs whose base is develop.
-# codecov + readthedocs checks are ignored (advisory). Fail-safe: if a merge
-# is blocked by branch policy the PR simply stays open.
+# so this file must stay on main, acting only on PRs whose base is develop
+# (unchanged from before).
 on:
   check_suite:
     types: [completed]
@@ -14,36 +14,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  automerge:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.check_suite.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: merge green PRs targeting develop
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
-        run: |
-          set -uo pipefail
-          if [ -n "${HEAD_SHA:-}" ]; then
-            prs=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[] | select(.state=="open") | .number' 2>/dev/null || true)
-          else
-            prs=$(gh pr list --repo "$REPO" --base develop --state open --json number --jq '.[].number' 2>/dev/null || true)
-          fi
-          [ -z "${prs:-}" ] && { echo "no open PRs"; exit 0; }
-          for pr in $prs; do
-            base=$(gh pr view "$pr" --repo "$REPO" --json baseRefName --jq .baseRefName 2>/dev/null || echo "")
-            [ "$base" = "develop" ] || { echo "skip #$pr (base=$base, not develop)"; continue; }
-            draft=$(gh pr view "$pr" --repo "$REPO" --json isDraft --jq .isDraft 2>/dev/null || echo true)
-            [ "$draft" = "true" ] && continue
-            pending=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq '
-              [ .statusCheckRollup[]
-                | select(((.name // .context // "") | ascii_downcase | test("codecov|readthedocs")) | not)
-                | (.conclusion // .state // "")
-                | select(. != "SUCCESS" and . != "NEUTRAL" and . != "SKIPPED" and . != "") ] | length' 2>/dev/null || echo 1)
-            if [ "$pending" = "0" ]; then
-              gh pr merge "$pr" --repo "$REPO" --merge --admin --delete-branch && echo "MERGED #$pr -> develop" || echo "blocked #$pr"
-            else
-              echo "PR #$pr not green ($pending) — skip"
-            fi
-          done
+  call:
+    uses: scitex-ai/.github/.github/workflows/auto-merge-to-develop.yml@main
+    secrets: inherit

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,5 +1,20 @@
 name: CLA Assistant
 
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers/permissions preserved verbatim from the prior local file.
+# Reusable workflow defaults (owner_login=ywatanabe1989,
+# owner_allowlist="bot*,ywatanabe1989", default_branch=main) already match
+# this repo's prior hardcoded values, so no `with:` overrides are needed.
+# NOTE: this repo's on: has no `push` trigger, so the reusable's
+# owner-bypass job (guarded by `if: github.event_name == 'push'`) never
+# fires here — same as before (this repo never had an owner-bypass job).
+# NOTE (pre-existing, unrelated to this migration): the prior local file
+# referenced `secrets.CROSSREF_LOCAL_PERSONAL_ACCESS_TOKEN`, but the repo's
+# actual configured secret is named `PERSONAL_ACCESS_TOKEN` (no prefix) —
+# neither that name nor the reusable's expected `GH_PERSONAL_ACCESS_TOKEN`
+# match, so PERSONAL_ACCESS_TOKEN resolves empty before and after this PR
+# (no regression; flagged for a follow-up secret rename/add).
+
 on:
   issue_comment:
     types: [created]
@@ -13,21 +28,6 @@ permissions:
   statuses: write
 
 jobs:
-  CLAssistant:
-    runs-on: ubuntu-latest
-    steps:
-      - name: CLA Assistant
-        uses: contributor-assistant/github-action@v2.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CROSSREF_LOCAL_PERSONAL_ACCESS_TOKEN }}
-        with:
-          path-to-signatures: "signatures/cla.json"
-          path-to-document: "https://github.com/ywatanabe1989/crossref-local/blob/main/CLA.md"
-          branch: "cla-signatures"
-          allowlist: bot*,ywatanabe1989
-          custom-allsigned-prcomment: |
-            Thank you for signing the SciTeX CLA. Your contribution can now be reviewed.
-          custom-notsigned-prcomment: |
-            Please sign the [SciTeX CLA](https://github.com/ywatanabe1989/crossref-local/blob/main/CLA.md) before your contribution can be merged.
-            Comment `I have read and agree to the SciTeX CLA.` to sign.
+  call:
+    uses: scitex-ai/.github/.github/workflows/cla.yml@main
+    secrets: inherit

--- a/.github/workflows/crossref-local-quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/crossref-local-quality-audit-on-ubuntu-latest.yml
@@ -1,17 +1,17 @@
 name: quality
 
-# Single-package quality gate — runs `scitex-dev ecosystem audit-all`
-# against this package (audit-cli / audit-mcp-tools / audit-skills /
-# audit-python-apis / audit-project). Mirrors the canonical audit that
-# `tests/develop/test_audit.py` runs inside the test suite, but as a
-# standalone gate so an audit regression is visible even when the matrix
-# is skipped.
-#
-# --new-only: this package carries grandfathered pre-existing audit debt
-# (CLI naming on the `relay` leaf + a PATH.yaml example wrapper). The
-# gate fails only on NEWLY introduced violations so the release wave is
-# not blocked on debt that predates it; clear the baseline in a dedicated
-# follow-up and drop the flag.
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Same purpose as before (`scitex-dev ecosystem audit-all` gate), now via
+# scitex-ai/.github's quality-audit reusable workflow.
+# NOTE (behavior delta): the reusable audit job runs
+# `scitex-dev ecosystem audit-all "$DIST" --path "$PWD"` (no `--new-only`,
+# no `--no-version-check`) — this repo's prior invocation passed both
+# flags to grandfather pre-existing findings (CLI naming on the `relay`
+# leaf + a PATH.yaml example wrapper). Flagged in the PR description; may
+# reintroduce those pre-existing findings as visible (non-required-check)
+# CI failures on this job specifically.
+# Runner/install now self-hosted spartan-cpu + uv (was ubuntu-latest + pip).
+# Triggers preserved verbatim from the prior local file.
 
 on:
   schedule:
@@ -28,21 +28,7 @@ on:
     branches: [main, develop]
 
 jobs:
-  audit:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install package + audit tooling
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-          pip install "scitex-dev[cli-audit]"
-
-      - name: Run scitex-dev ecosystem audit-all
-        run: scitex-dev ecosystem audit-all crossref-local --no-version-check --new-only
+  quality-audit:
+    # New required-status-check context: "quality-audit / audit"
+    uses: scitex-ai/.github/.github/workflows/quality-audit.yml@main
+    secrets: inherit

--- a/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
+++ b/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
@@ -1,11 +1,11 @@
 name: import-smoke
 
-# Catches "wheel installs but `import crossref_local` blows up at runtime"
-# — separate from the full pytest suite so a broken entry-point fails
-# fast without paying for the matrix. Companion to `tests` — confirms
-# the bare package (no extras) is `pip install -e .`-able and
-# `import crossref_local` succeeds. Catches `[project] dependencies`
-# drift that the test matrix masks because it installs `[all,dev]`.
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Same purpose as before (bare `pip install -e .` + `import crossref_local`
+# smoke check), now via scitex-ai/.github's import-smoke reusable workflow.
+# NOTE: runner/install now self-hosted spartan-cpu + uv (was ubuntu-latest
+# + venv/pip) — same infra-normalization note as pytest-matrix, see PR.
+# Triggers preserved verbatim from the prior local file.
 
 on:
   push:
@@ -17,18 +17,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  install-check:
-    name: import-smoke-on-ubuntu-py3-12
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install (no extras)
-        run: |
-          python -m venv .venv
-          .venv/bin/pip install --upgrade pip
-          .venv/bin/pip install -e .
-      - name: Import smoke
-        run: .venv/bin/python -c "import crossref_local; print(crossref_local.__version__)"
+  import-smoke:
+    # New required-status-check context: "import-smoke / import-smoke-on-ubuntu-py3-12"
+    uses: scitex-ai/.github/.github/workflows/import-smoke.yml@main
+    secrets: inherit

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -1,5 +1,17 @@
 name: tests
 
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Replaces the formerly-inlined `test` job with a thin `uses:` call into
+# scitex-ai/.github's pytest-matrix reusable workflow — same purpose
+# (pytest matrix across 3.11/3.12/3.13), now centrally maintained.
+#
+# NOTE (real infra change, not just dedup): the reusable workflow runs on
+# the self-hosted spartan-cpu runner with `uv`-based installs; this repo's
+# prior job ran on `ubuntu-latest` with `pip`. Converting adopts the
+# org-canonical runner/install path as part of fixing fleet CI drift —
+# flagged here and in the PR description for reviewer awareness.
+# Triggers preserved verbatim from the prior local file.
+
 on:
   push:
     branches: [main, develop]
@@ -10,39 +22,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    name: pytest-matrix-on-ubuntu-py${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          # Fallback chain: prefer [all,dev] so optional-dep code paths
-          # (yaml, fastmcp, textual) get exercised. Falls back to [dev] then
-          # plain editable so a packaging hiccup doesn't strand CI.
-          pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
-      - name: Run tests
-        run: |
-          pytest tests/ --cov=src/crossref_local --cov-report=xml --cov-report=term
-      - name: Upload coverage to Codecov
-        if: always()
-        uses: codecov/codecov-action@v5
-        env:
-          # Per-matrix-job HOME so concurrent jobs sharing a self-hosted
-          # (Spartan) runner don't race on a shared $HOME/.gitconfig when
-          # codecov-action marks the workspace a safe.directory.
-          HOME: ${{ runner.temp }}/codecov-home-${{ matrix.python-version }}
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          fail_ci_if_error: false
-          disable_safe_directory: true
+  pytest-matrix:
+    # New required-status-check context: "pytest-matrix / pytest-matrix-on-ubuntu-py<X.YY>"
+    uses: scitex-ai/.github/.github/workflows/pytest-matrix.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Fleet-wide CI migration (last-but-one repo): converts crossref-local's per-file GitHub Actions workflows to thin caller stubs against `scitex-ai/.github`'s reusable workflows.
- Converted: `cla.yml`, `auto-merge-to-develop.yaml`, `import-smoke-on-ubuntu-py3-12.yml`, `pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml`, `crossref-local-quality-audit-on-ubuntu-latest.yml`.
- Left alone (does more than the reusable equivalent, or has no reusable equivalent, or is already migrated):
  - `pypi-publish-and-github-release-on-tag.yml` — already converted to self-hosted SIF + manual OIDC trusted publishing in PR #40; untouched here per fleet policy (PyPI OIDC trusted publishing does not support `workflow_call` reusable workflows — `invalid-publisher` error — confirmed against PyPI docs for the original scitex-stats pilot, PR #69).
  - `rtd-sphinx-build-on-ubuntu-latest.yml` — builds from `docs/sphinx/conf.py`, a path the reusable's conf.py auto-discovery does not check (`docs/conf.py`, `docs/source/conf.py`, `docs/src/conf.py` only — would silently no-op/skip on this repo), and also auto-commits built HTML back to `src/crossref_local/_sphinx_html/` on develop pushes, which the reusable does not do.
  - `newb-docs-quality-on-ubuntu-latest.yml` — runs a Docker container (`ghcr.io/ywatanabe1989/newb-runner`) on a weekly cron; Spartan self-hosted runners are apptainer-only (no Docker), so this cannot move to the fleet's self-hosted runner, and no reusable-workflow equivalent exists fleet-wide either. Left on `ubuntu-latest` (repo is public, so this costs nothing) rather than break a working feature.

## New required-status-check contexts
- `import-smoke-on-ubuntu-py3-12` → `import-smoke / import-smoke-on-ubuntu-py3-12`
- `pytest-matrix-on-ubuntu-py3.11/12/13` → `pytest-matrix / pytest-matrix-on-ubuntu-py3.11` (`.12`, `.13`)
- `audit` → `quality-audit / audit`
- `CLAssistant` → `call / CLAssistant`

## Branch protection
Checked `develop` and `main` branch protection on this repo — neither currently has `required_status_checks` configured, so there is no required-check-name mismatch to coordinate here (unlike scitex-stats/scitex-dsp, which did require the old `pytest-matrix-on-ubuntu-py3.1x` contexts). No branch-protection update is needed for this PR to be mergeable.

## Judgment calls / notes
- **`crossref-local-quality-audit-on-ubuntu-latest.yml`**: the prior local job passed `--new-only --no-version-check` to grandfather pre-existing findings (CLI naming on the `relay` leaf + a PATH.yaml example wrapper, per the file's own comment). The reusable `quality-audit.yml` runs the full, un-flagged audit (`scitex-dev ecosystem audit-all "$DIST" --path "$PWD"`). This may resurface those pre-existing findings as a red `quality-audit` job. `quality-audit` is not a required status check on this repo (see above), so this cannot block merging, but watch the PR's `quality-audit / audit` check — if it goes red on pre-existing debt rather than something this PR introduced, that's expected and matches the same accepted behavior delta used in the scitex-dsp migration (PR #39).
- **`cla.yml`**: this repo's allowlist (`bot*,ywatanabe1989`) already matches the reusable's default, so no `with:` override is needed. Separately (pre-existing, unrelated to this migration): the prior local file referenced `secrets.CROSSREF_LOCAL_PERSONAL_ACCESS_TOKEN`, which does not exist as a repo secret (the actual secret is named `PERSONAL_ACCESS_TOKEN`); the reusable workflow expects `secrets.GH_PERSONAL_ACCESS_TOKEN`, which also does not exist. Both resolve to an empty `PERSONAL_ACCESS_TOKEN` env var before and after this PR — no regression, just flagging a latent secret-naming mismatch for a follow-up.
- Everything else (`pytest-matrix`, `import-smoke`, `auto-merge-to-develop`) is a pure mechanical extraction — same steps, same runner labels (`self-hosted, Linux, X64, spartan-cpu`), same action version pins as the already-merged Group D repos.

## Secrets
`secrets: inherit` is set on every `uses:` job. `CODECOV_TOKEN` is not configured as a repo secret; the codecov upload step already tolerates that (`fail_ci_if_error: false`), matching this repo's prior behavior.

## Verification done
- All 5 changed YAML files parse (`python3 -c "import yaml; yaml.safe_load(open(f))"`).
- Diff is job-body-only; every trigger/concurrency/permissions block is byte-identical to the pre-PR file.
- Confirmed via `gh secret list` / `gh variable list` that this repo already has the Spartan self-hosted infra (`CI_RUNS_ON`, `SCITEX_CI_APPTAINER`, `SCITEX_CI_SIF` vars, and an existing Spartan runner directory) that the reusable workflows' `runs-on: [self-hosted, Linux, X64, spartan-cpu]` targets.
- Real CI on this PR: see check-run status below / at merge time (pytest-matrix, import-smoke, quality-audit, CLAssistant all expected green; quality-audit may show pre-existing debt per the note above).
