### PR TITLE
fix(license): clarify AGPL-3.0-only in How-to-Apply template text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -634,8 +634,7 @@ the "copyright" line and a pointer to where the full notice is found.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+    the Free Software Foundation, version 3 of the License only.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
## Summary
- The LICENSE file's "How to Apply These Terms to Your New Programs" section
  (an FSF template, not part of the operative legal terms in sections 0-17)
  still carried the generic "or (at your option) any later version" wording.
- This contradicts `pyproject.toml`'s `license = "AGPL-3.0-only"` declaration.
- Sections 0-17 (the actual legal terms) are untouched -- this is a one-line
  edit inside the non-operative template text at the end of the file only.

## Change
```
- the Free Software Foundation, either version 3 of the License, or
-     (at your option) any later version.
+ the Free Software Foundation, version 3 of the License only.
```

Operator-authorized, applied uniformly across scitex-ai packages.
