### PR TITLE
ci: run pytest on Spartan, not GitHub-hosted runners

### DIFF
--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -1,5 +1,17 @@
 name: tests
 
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Replaces the formerly-inlined `test` job with a thin `uses:` call into
+# scitex-ai/.github's pytest-matrix reusable workflow — same purpose
+# (pytest matrix across 3.11/3.12/3.13), now centrally maintained.
+#
+# NOTE (real infra change, not just dedup): the reusable workflow runs on
+# the self-hosted spartan-cpu runner with `uv`-based installs; this repo's
+# prior job ran on `ubuntu-latest` with `pip`. Converting adopts the
+# org-canonical runner/install path as part of fixing fleet CI drift —
+# flagged here and in the PR description for reviewer awareness.
+# Triggers preserved verbatim from the prior local file.
+
 on:
   push:
     branches: [main, develop]
@@ -10,39 +22,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    name: pytest-matrix-on-ubuntu-py${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          # Fallback chain: prefer [all,dev] so optional-dep code paths
-          # (yaml, fastmcp, textual) get exercised. Falls back to [dev] then
-          # plain editable so a packaging hiccup doesn't strand CI.
-          pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
-      - name: Run tests
-        run: |
-          pytest tests/ --cov=src/crossref_local --cov-report=xml --cov-report=term
-      - name: Upload coverage to Codecov
-        if: always()
-        uses: codecov/codecov-action@v5
-        env:
-          # Per-matrix-job HOME so concurrent jobs sharing a self-hosted
-          # (Spartan) runner don't race on a shared $HOME/.gitconfig when
-          # codecov-action marks the workspace a safe.directory.
-          HOME: ${{ runner.temp }}/codecov-home-${{ matrix.python-version }}
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          fail_ci_if_error: false
-          disable_safe_directory: true
+  pytest-matrix:
+    # New required-status-check context: "pytest-matrix / pytest-matrix-on-ubuntu-py<X.YY>"
+    uses: scitex-ai/.github/.github/workflows/pytest-matrix.yml@main
+    secrets: inherit


### PR DESCRIPTION
Promotes develop's already-migrated pytest workflow (a thin caller of the org reusable `pytest-matrix`, which pins `runs-on: [self-hosted, Linux, X64, spartan-cpu]`) onto `main`, which still ran on `ubuntu-latest`.

Piloted first, one repo per class, both green on Spartan:
- **scitex-dict#24** — protection still carried the pre-migration (bare) check names, so it had to be reconciled to the emitted `pytest-matrix / ...` names in the same change. Every check was green with `mergeStateStatus: BLOCKED` until then.
- **scitex-os#29** — protection *already* required the post-migration names, so no protection change was needed; the promotion actually **repaired** a repo whose main PRs could never satisfy their required checks.

Which case this repo is was determined by reading its actual protection and the names this PR actually emits — not by assuming. Context: the org runner pool now dispatches (it previously excluded public repos silently, so jobs queued forever with no error).