### PR TITLE
feat: info() never full-scans — db_stats exact-count cache + labelled estimates (0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-07-22
+
+### Added
+- **`db_stats` exact-count cache** (`_core/stats.py`) — small table
+  `db_stats(table_name TEXT PRIMARY KEY, row_count INTEGER, computed_at TEXT)`
+  holding exact `COUNT(*)` results for `works` / `works_fts` / `citations`
+- `refresh_stats()` public API + `crossref-local refresh-stats` CLI command —
+  compute exact counts and write the cache (the only write path; also wired
+  into `crossref-local update` after a successful sync)
+- `counts_source` (`"exact"` / `"estimated"` / `"unavailable"`) and
+  `counts_computed_at` fields in `info()` and the HTTP `/info` response —
+  estimates are never silently presented as exact
+
+### Changed
+- **`info()` no longer full-scans large tables** (DB mode, async `aio.info()`,
+  and the server `/info` endpoint). Production measurements (2026-07-22):
+  `COUNT(*)` on works=167,008,748 rows took 0.42s, works_fts 12.70s (FTS5
+  scans everything), citations=1,788,599,072 rows 4.35s — ~17.5s per call.
+  Counts now come from the `db_stats` cache (exact) or `MAX(rowid)` estimates
+  (~0.02s); `info()` needs no write access, so read-only deployments work
+
 ## [0.4.0] - 2026-01-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "crossref-local"
-version = "0.7.6"
+version = "0.8.0"
 description = "Local CrossRef database with 167M+ works and full-text search"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/database/10_differential_update.py
+++ b/scripts/database/10_differential_update.py
@@ -430,6 +430,22 @@ def differential_update(
         conn, "last_update_completed", time.strftime("%Y-%m-%d %H:%M:%S")
     )
     set_metadata(conn, "last_update_records", str(upserted))
+    conn.close()
+
+    # Refresh the db_stats exact-count cache so info() / the /info
+    # endpoint report exact counts without ever running COUNT(*)
+    # themselves (~17.5 s on the production DB). Slow here is fine —
+    # an update run already takes minutes.
+    try:
+        from crossref_local._core.stats import refresh_stats
+
+        refresh_stats(db_path)
+        logger.info("db_stats cache refreshed (exact counts)")
+    except ImportError:
+        logger.warning(
+            "crossref_local not importable — db_stats cache NOT "
+            "refreshed; run `crossref-local refresh-stats` manually"
+        )
 
     elapsed = time.time() - start_time
     logger.info("=" * 60)
@@ -438,7 +454,6 @@ def differential_update(
     logger.info(f"  New last_sync_date: {today}")
     logger.info(f"  Elapsed: {elapsed / 60:.1f} minutes")
 
-    conn.close()
     return {
         "records_upserted": upserted,
         "elapsed_seconds": elapsed,

--- a/src/crossref_local/__init__.py
+++ b/src/crossref_local/__init__.py
@@ -127,6 +127,7 @@ from ._core import (
     configure_remote,
     get_mode,
     info,
+    refresh_stats,
     # Models
     Work,
     SearchResult,
@@ -199,6 +200,7 @@ __all__ = [
     "configure_remote",  # Backward compatibility alias
     "get_mode",
     "info",
+    "refresh_stats",
     # Data models
     "Work",
     "SearchResult",

--- a/src/crossref_local/_aio/_impl.py
+++ b/src/crossref_local/_aio/_impl.py
@@ -96,29 +96,17 @@ def _exists_sync(doi: str) -> bool:
 
 
 def _info_sync() -> dict:
-    """Thread-safe sync info."""
+    """Thread-safe sync info.
+
+    Counts come from the ``db_stats`` cache (exact) or ``MAX(rowid)``
+    estimates — never ``COUNT(*)`` full scans. See ``_core/stats.py``.
+    """
+    from .._core.stats import get_counts as _get_counts
+
     db = _get_thread_db()
-
-    row = db.fetchone("SELECT COUNT(*) as count FROM works")
-    work_count = row["count"] if row else 0
-
-    try:
-        row = db.fetchone("SELECT COUNT(*) as count FROM works_fts")
-        fts_count = row["count"] if row else 0
-    except Exception:
-        fts_count = 0
-
-    try:
-        row = db.fetchone("SELECT COUNT(*) as count FROM citations")
-        citation_count = row["count"] if row else 0
-    except Exception:
-        citation_count = 0
-
     return {
         "db_path": str(_Config.get_db_path()),
-        "works": work_count,
-        "fts_indexed": fts_count,
-        "citations": citation_count,
+        **_get_counts(db),
     }
 
 

--- a/src/crossref_local/_cli/cli.py
+++ b/src/crossref_local/_cli/cli.py
@@ -300,6 +300,11 @@ from .update import update_cmd
 
 cli.add_command(update_cmd)
 
+# Register refresh-stats command (extracted for the same line limit)
+from .stats import refresh_stats_cmd
+
+cli.add_command(refresh_stats_cmd)
+
 
 @cli.command("relay", context_settings=CONTEXT_SETTINGS)
 @click.option("--host", default=None, envvar="CROSSREF_LOCAL_HOST", help="Host to bind")

--- a/src/crossref_local/_cli/stats.py
+++ b/src/crossref_local/_cli/stats.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""``refresh-stats`` command for the crossref-local CLI.
+
+Thin Click wrapper over :func:`crossref_local._core.stats.refresh_stats`.
+Kept in its own module (mirroring ``update.py``) to honour the line
+limit on ``cli.py``.
+"""
+
+import sys
+import time
+
+import click
+
+
+@click.command("refresh-stats")
+@click.option(
+    "--db",
+    "db_path",
+    type=click.Path(),
+    default=None,
+    help="Database path override (else use auto-discovery).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def refresh_stats_cmd(db_path, as_json):
+    """Recompute exact table counts into the ``db_stats`` cache.
+
+    Runs COUNT(*) on works / works_fts / citations (slow — ~17.5 s on
+    the production database) and writes the results to the ``db_stats``
+    table, so ``info()`` and the HTTP ``/info`` endpoint can report
+    exact counts instantly (``counts_source: "exact"``). Without this
+    cache they fall back to fast MAX(rowid) estimates.
+
+    Requires write access to the database. Run after ingest/rebuild
+    (``crossref-local update`` runs it automatically).
+
+    \b
+    Example:
+      $ crossref-local refresh-stats
+      $ crossref-local refresh-stats --db /path/to/crossref.db
+      $ crossref-local refresh-stats --json
+    """
+    import json as json_module
+
+    from .._core.stats import refresh_stats
+
+    started = time.time()
+    try:
+        counts = refresh_stats(db_path=db_path)
+    except FileNotFoundError as e:
+        click.secho(f"Error: {e}", fg="red", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.secho(
+            f"Error: could not refresh stats ({e}). "
+            "Is the database writable?",
+            fg="red",
+            err=True,
+        )
+        sys.exit(1)
+    elapsed = time.time() - started
+
+    if as_json:
+        click.echo(json_module.dumps(counts, indent=2))
+        return
+
+    click.secho("db_stats cache refreshed (exact counts):", fg="green")
+    click.echo(f"  Works:       {counts['works']:,}")
+    click.echo(f"  FTS indexed: {counts['fts_indexed']:,}")
+    click.echo(f"  Citations:   {counts['citations']:,}")
+    click.echo(f"  Computed at: {counts['counts_computed_at']}")
+    click.echo(f"  Elapsed:     {elapsed:.1f}s")
+
+
+# EOF

--- a/src/crossref_local/_core/__init__.py
+++ b/src/crossref_local/_core/__init__.py
@@ -13,6 +13,7 @@ from .api import (
     get_many,
     get_mode,
     info,
+    refresh_stats,
     search,
 )
 from .citations import (
@@ -41,6 +42,7 @@ __all__ = [
     "configure_remote",
     "get_mode",
     "info",
+    "refresh_stats",
     # Models
     "Work",
     "SearchResult",

--- a/src/crossref_local/_core/api.py
+++ b/src/crossref_local/_core/api.py
@@ -12,10 +12,11 @@ Mode is auto-detected or can be set explicitly via:
 
 from typing import List, Optional
 
-from . import fts
+from . import fts, stats
 from .config import Config
 from .db import close_db, get_db
 from .models import SearchResult, Work
+from .stats import refresh_stats
 
 __all__ = [
     "search",
@@ -30,6 +31,7 @@ __all__ = [
     "enrich_dois",
     "get_mode",
     "info",
+    "refresh_stats",
     # Re-exported for convenience
     "Work",
     "SearchResult",
@@ -278,6 +280,13 @@ def info() -> dict:
     """
     Get database/API information.
 
+    Fast by design: counts come from the ``db_stats`` cache (exact,
+    written by :func:`refresh_stats`) or from ``MAX(rowid)`` estimates
+    when the cache is absent — never from ``COUNT(*)`` full scans
+    (~17.5 s on the production database). The ``counts_source`` field
+    labels which path produced the numbers (``"exact"`` /
+    ``"estimated"`` / ``"unavailable"``).
+
     Returns:
         Dictionary with database stats and mode info
     """
@@ -310,10 +319,19 @@ def info() -> dict:
                 result["works"] = info_data.get("total_papers", 0)
                 result["fts_indexed"] = info_data.get("fts_indexed", 0)
                 result["citations"] = info_data.get("citations", 0)
+                # Older servers do not send counts_source — label their
+                # MAX(rowid)-style numbers honestly as estimates.
+                result["counts_source"] = info_data.get(
+                    "counts_source", "estimated"
+                )
+                result["counts_computed_at"] = info_data.get(
+                    "counts_computed_at"
+                )
         except Exception:
             result["works"] = 0
             result["fts_indexed"] = 0
             result["citations"] = 0
+            result["counts_source"] = "unavailable"
             result["note"] = "/info timed out (server may need update)"
         finally:
             client.timeout = old_timeout
@@ -321,29 +339,13 @@ def info() -> dict:
 
     db = get_db()
 
-    # Get work count
-    row = db.fetchone("SELECT COUNT(*) as count FROM works")
-    work_count = row["count"] if row else 0
-
-    # Get FTS count
-    try:
-        row = db.fetchone("SELECT COUNT(*) as count FROM works_fts")
-        fts_count = row["count"] if row else 0
-    except Exception:
-        fts_count = 0
-
-    # Get citations count
-    try:
-        row = db.fetchone("SELECT COUNT(*) as count FROM citations")
-        citation_count = row["count"] if row else 0
-    except Exception:
-        citation_count = 0
+    # Cache-first counts (exact when db_stats is present, MAX(rowid)
+    # estimates otherwise). NEVER COUNT(*) — see _core/stats.py.
+    counts = stats.get_counts(db)
 
     return {
         "mode": "db",
         "status": "ok",
         "db_path": str(Config.get_db_path()),
-        "works": work_count,
-        "fts_indexed": fts_count,
-        "citations": citation_count,
+        **counts,
     }

--- a/src/crossref_local/_core/stats.py
+++ b/src/crossref_local/_core/stats.py
@@ -1,0 +1,184 @@
+"""Fast database statistics with an exact-count cache.
+
+``COUNT(*)`` is prohibitively slow on the production database
+(measured 2026-07-22: ``works`` 167,008,748 rows -> 0.42 s;
+``works_fts`` -> 12.70 s because FTS5 virtual tables scan everything;
+``citations`` 1,788,599,072 rows -> 4.35 s; ~17.5 s total per
+``info()`` call). ``SELECT MAX(rowid)`` returns the same magnitude in
+~0.02 s.
+
+This module keeps ``info()`` O(1):
+
+- :func:`read_cached_counts` reads the ``db_stats`` cache table
+  (exact counts written by :func:`refresh_stats`).
+- :func:`estimate_counts` returns cheap ``MAX(rowid)`` estimates.
+- :func:`get_counts` is the read path: cache first, estimate
+  fallback — the result is ALWAYS labelled via ``counts_source``
+  (``"exact"`` or ``"estimated"``); an estimate is never silently
+  presented as exact, and the read path NEVER runs ``COUNT(*)``.
+- :func:`refresh_stats` computes exact ``COUNT(*)`` per table and
+  writes the cache. This is the ONLY function that writes; ``info()``
+  on a read-only database (no ``db_stats`` table) just estimates.
+
+Cache schema::
+
+    CREATE TABLE db_stats (
+        table_name  TEXT PRIMARY KEY,
+        row_count   INTEGER,
+        computed_at TEXT
+    )
+"""
+
+import sqlite3 as _sqlite3
+from datetime import datetime as _datetime
+from datetime import timezone as _timezone
+from pathlib import Path as _Path
+from typing import Optional as _Optional
+
+from .config import Config as _Config
+
+__all__ = [
+    "STATS_TABLES",
+    "read_cached_counts",
+    "estimate_counts",
+    "get_counts",
+    "refresh_stats",
+]
+
+# (sqlite table, public info() key) pairs — order defines output order.
+STATS_TABLES = (
+    ("works", "works"),
+    ("works_fts", "fts_indexed"),
+    ("citations", "citations"),
+)
+
+
+def read_cached_counts(db) -> _Optional[dict]:
+    """Read exact counts from the ``db_stats`` cache table.
+
+    Args:
+        db: A :class:`crossref_local._core.db.Database` (or any object
+            with ``fetchall(query)``).
+
+    Returns:
+        ``{"works": n, "fts_indexed": n, "citations": n,
+        "counts_computed_at": <ISO timestamp>}`` when the cache covers
+        every tracked table, else ``None`` (absent table, unreadable
+        row, or partial coverage — the caller then estimates).
+    """
+    try:
+        rows = db.fetchall(
+            "SELECT table_name, row_count, computed_at FROM db_stats"
+        )
+    except Exception:
+        return None
+
+    by_table = {row["table_name"]: row for row in rows}
+    if any(table not in by_table for table, _key in STATS_TABLES):
+        return None
+
+    counts = {}
+    computed_stamps = []
+    for table, key in STATS_TABLES:
+        row = by_table[table]
+        row_count = row["row_count"]
+        if not isinstance(row_count, int):
+            return None
+        counts[key] = row_count
+        computed_stamps.append(row["computed_at"])
+
+    # Report the OLDEST stamp: the honest age of the least-fresh count.
+    counts["counts_computed_at"] = min(
+        (s for s in computed_stamps if s), default=None
+    )
+    return counts
+
+
+def estimate_counts(db) -> dict:
+    """Cheap row-count estimates via ``MAX(rowid)`` (never ``COUNT(*)``).
+
+    ``MAX(rowid)`` is O(1) on rowid tables and equals the row count for
+    append-only tables (rowids allocated sequentially, no deletes) —
+    which is how the ingest pipeline writes. A table that is absent or
+    unreadable reports 0, matching the previous ``info()`` behaviour.
+    """
+    counts = {}
+    for table, key in STATS_TABLES:
+        try:
+            row = db.fetchone(f"SELECT MAX(rowid) AS n FROM {table}")
+            counts[key] = row["n"] if row and row["n"] is not None else 0
+        except Exception:
+            counts[key] = 0
+    counts["counts_computed_at"] = None
+    return counts
+
+
+def get_counts(db) -> dict:
+    """Fast, honestly-labelled table counts (the ``info()`` read path).
+
+    Reads the ``db_stats`` cache when present (``counts_source:
+    "exact"``); otherwise falls back to ``MAX(rowid)`` estimates
+    (``counts_source: "estimated"``). Never runs ``COUNT(*)`` and never
+    writes — safe on read-only databases.
+    """
+    cached = read_cached_counts(db)
+    if cached is not None:
+        cached["counts_source"] = "exact"
+        return cached
+    estimated = estimate_counts(db)
+    estimated["counts_source"] = "estimated"
+    return estimated
+
+
+def refresh_stats(db_path: _Optional[str | _Path] = None) -> dict:
+    """Compute exact ``COUNT(*)`` per table and write the cache.
+
+    Slow by design (~17.5 s on the production database) — run it from
+    the ingest/update pipeline or ``crossref-local refresh-stats``, not
+    from ``info()``. Requires write access (creates ``db_stats`` if
+    absent).
+
+    Args:
+        db_path: Database path override; defaults to the configured DB.
+
+    Returns:
+        The freshly computed counts, same shape as :func:`get_counts`
+        (``counts_source: "exact"``).
+
+    Raises:
+        sqlite3.OperationalError: If the database is not writable.
+    """
+    path = _Path(db_path) if db_path else _Config.get_db_path()
+    computed_at = _datetime.now(_timezone.utc).isoformat(timespec="seconds")
+
+    conn = _sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS db_stats ("
+            "table_name TEXT PRIMARY KEY, "
+            "row_count INTEGER, "
+            "computed_at TEXT)"
+        )
+        counts = {}
+        for table, key in STATS_TABLES:
+            try:
+                n = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            except _sqlite3.OperationalError:
+                # Table absent (e.g. minimal DB without citations):
+                # record 0 — same convention the old info() used.
+                n = 0
+            conn.execute(
+                "INSERT OR REPLACE INTO db_stats "
+                "(table_name, row_count, computed_at) VALUES (?, ?, ?)",
+                (table, n, computed_at),
+            )
+            counts[key] = n
+        conn.commit()
+    finally:
+        conn.close()
+
+    counts["counts_computed_at"] = computed_at
+    counts["counts_source"] = "exact"
+    return counts
+
+# EOF

--- a/src/crossref_local/_server/__init__.py
+++ b/src/crossref_local/_server/__init__.py
@@ -86,32 +86,26 @@ def health():
 
 @app.get("/info")
 def info():
-    """Get database statistics."""
+    """Get database statistics.
+
+    Counts come from the ``db_stats`` cache (exact, written by
+    ``refresh_stats``) or ``MAX(rowid)`` estimates when the cache is
+    absent — never ``COUNT(*)`` full scans (~17.5 s on 167M+ rows).
+    ``counts_source`` labels which path produced the numbers.
+    """
     from .._core.db import get_db
+    from .._core.stats import get_counts
     from .models import InfoResponse
 
     db = get_db()
-
-    # Use MAX(rowid) as fast O(1) approximation (COUNT(*) is too slow on 167M+ rows)
-    row = db.fetchone("SELECT MAX(rowid) as count FROM works")
-    work_count = row["count"] if row else 0
-
-    try:
-        row = db.fetchone("SELECT MAX(rowid) as count FROM works_fts")
-        fts_count = row["count"] if row else 0
-    except Exception:
-        fts_count = 0
-
-    try:
-        row = db.fetchone("SELECT MAX(rowid) as count FROM citations")
-        citation_count = row["count"] if row else 0
-    except Exception:
-        citation_count = 0
+    counts = get_counts(db)
 
     return InfoResponse(
-        total_papers=work_count,
-        fts_indexed=fts_count,
-        citations=citation_count,
+        total_papers=counts["works"],
+        fts_indexed=counts["fts_indexed"],
+        citations=counts["citations"],
+        counts_source=counts["counts_source"],
+        counts_computed_at=counts["counts_computed_at"],
         database_path=str(db.db_path),
     )
 

--- a/src/crossref_local/_server/models.py
+++ b/src/crossref_local/_server/models.py
@@ -47,7 +47,11 @@ class SearchResponse(BaseModel):
 
 
 class InfoResponse(BaseModel):
-    """Database info response."""
+    """Database info response.
+
+    ``counts_source`` labels how the counts were produced: ``"exact"``
+    (from the ``db_stats`` cache) or ``"estimated"`` (``MAX(rowid)``).
+    """
 
     name: str = "CrossRef Local API"
     version: str = __version__
@@ -56,6 +60,8 @@ class InfoResponse(BaseModel):
     total_papers: int
     fts_indexed: int
     citations: Optional[int] = 0
+    counts_source: str = "estimated"
+    counts_computed_at: Optional[str] = None
     database_path: str
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,8 @@ _DB_OPTIONAL_TEST_MODULES = frozenset(
         "test_cross_package_imports",
         "test_audit",
         "test_paths_runtime",
+        # Builds its own tiny SQLite DBs — no shared fixture DB needed.
+        "test_stats",
     }
 )
 

--- a/tests/crossref_local/test_api.py
+++ b/tests/crossref_local/test_api.py
@@ -238,6 +238,20 @@ def test_info_dict_reports_positive_works_count(_db_info):
     assert _db_info["works"] > 0
 
 
+def test_info_dict_contains_counts_source_key(_db_info):
+    # Arrange
+    # Act
+    # Assert
+    assert "counts_source" in _db_info
+
+
+def test_info_counts_source_is_honest_label(_db_info):
+    # Arrange
+    # Act
+    # Assert
+    assert _db_info["counts_source"] in {"exact", "estimated", "unavailable"}
+
+
 # ---------- enrich() ----------
 
 

--- a/tests/crossref_local/test_server.py
+++ b/tests/crossref_local/test_server.py
@@ -152,6 +152,23 @@ def test_info_endpoint_total_papers_field_is_integer(client):
     assert isinstance(data["total_papers"], int)
 
 
+def test_info_endpoint_includes_counts_source_field(client):
+    # Arrange
+    # Act
+    data = client.get("/info").json()
+    # Assert
+    assert "counts_source" in data
+
+
+def test_info_endpoint_counts_source_is_honest_label(client):
+    # Arrange
+    # Act
+    data = client.get("/info").json()
+    # Assert — cache-backed "exact" or MAX(rowid) "estimated"; never a
+    # silent COUNT(*) full scan
+    assert data["counts_source"] in {"exact", "estimated"}
+
+
 # ---------- /works search ----------
 
 

--- a/tests/crossref_local/test_stats.py
+++ b/tests/crossref_local/test_stats.py
@@ -1,0 +1,349 @@
+"""Tests for crossref_local._core.stats (db_stats cache + estimates).
+
+These tests build their own tiny SQLite databases, so they run without
+the shared fixture/production database (module is listed in
+``_DB_OPTIONAL_TEST_MODULES`` in ``tests/conftest.py``).
+"""
+
+import os
+import sqlite3
+
+import pytest
+
+from crossref_local._core.db import Database, close_db
+from crossref_local._core.config import Config
+from crossref_local._core.stats import (
+    estimate_counts,
+    get_counts,
+    read_cached_counts,
+    refresh_stats,
+)
+
+WORKS_ROWS = 5
+FTS_ROWS = 3
+CITATION_ROWS = 7
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """Create a small crossref-shaped SQLite DB (no db_stats table)."""
+    path = tmp_path / "mini_crossref.db"
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE works (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "doi VARCHAR(255), metadata BLOB)"
+    )
+    for i in range(WORKS_ROWS):
+        conn.execute(
+            "INSERT INTO works (doi, metadata) VALUES (?, ?)",
+            (f"10.1234/work{i}", "{}"),
+        )
+    conn.execute(
+        "CREATE VIRTUAL TABLE works_fts USING fts5(title, abstract)"
+    )
+    for i in range(FTS_ROWS):
+        conn.execute(
+            "INSERT INTO works_fts (title, abstract) VALUES (?, ?)",
+            (f"title {i}", f"abstract {i}"),
+        )
+    conn.execute(
+        "CREATE TABLE citations (citing_doi TEXT, cited_doi TEXT)"
+    )
+    for i in range(CITATION_ROWS):
+        conn.execute(
+            "INSERT INTO citations (citing_doi, cited_doi) VALUES (?, ?)",
+            (f"10.1234/work{i % WORKS_ROWS}", "10.1234/work0"),
+        )
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def db(tmp_db):
+    """Open the mini DB through the package's Database wrapper."""
+    database = Database(tmp_db)
+    yield database
+    database.close()
+
+
+@pytest.fixture
+def configured_info(tmp_db):
+    """Point the package-level info() at the mini DB; restore afterwards."""
+    import crossref_local
+
+    crossref_local.configure(str(tmp_db))
+    yield crossref_local.info
+    Config.reset()
+    close_db()
+
+
+# ---------- estimate path (no cache) ----------
+
+
+def test_get_counts_without_cache_labels_source_estimated(db):
+    # Arrange
+    # Act
+    counts = get_counts(db)
+    # Assert
+    assert counts["counts_source"] == "estimated"
+
+
+def test_get_counts_without_cache_reports_works_via_max_rowid(db):
+    # Arrange
+    # Act
+    counts = get_counts(db)
+    # Assert
+    assert counts["works"] == WORKS_ROWS
+
+
+def test_get_counts_without_cache_reports_fts_indexed(db):
+    # Arrange
+    # Act
+    counts = get_counts(db)
+    # Assert
+    assert counts["fts_indexed"] == FTS_ROWS
+
+
+def test_get_counts_without_cache_reports_citations(db):
+    # Arrange
+    # Act
+    counts = get_counts(db)
+    # Assert
+    assert counts["citations"] == CITATION_ROWS
+
+
+def test_get_counts_without_cache_never_creates_db_stats_table(tmp_db, db):
+    # Arrange
+    # Act
+    get_counts(db)
+    # Assert — the read path must not write (read-only deployments)
+    conn = sqlite3.connect(str(tmp_db))
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name='db_stats'"
+    ).fetchone()
+    conn.close()
+    assert row is None
+
+
+def test_get_counts_on_readonly_db_file_still_estimates(tmp_db):
+    # Arrange
+    os.chmod(tmp_db, 0o444)
+    database = Database(tmp_db)
+    # Act
+    counts = get_counts(database)
+    # Assert
+    database.close()
+    os.chmod(tmp_db, 0o644)
+    assert counts["works"] == WORKS_ROWS
+
+
+def test_estimate_after_deletes_keeps_estimated_label(tmp_db, db):
+    # Arrange — deletes make MAX(rowid) diverge from COUNT(*), which is
+    # exactly why the label must say "estimated"
+    conn = sqlite3.connect(str(tmp_db))
+    conn.execute("DELETE FROM works WHERE id = 2")
+    conn.commit()
+    conn.close()
+    # Act
+    counts = estimate_counts(db)
+    # Assert — MAX(rowid) still reports the old magnitude
+    assert counts["works"] == WORKS_ROWS
+
+
+def test_read_cached_counts_returns_none_without_cache(db):
+    # Arrange
+    # Act
+    cached = read_cached_counts(db)
+    # Assert
+    assert cached is None
+
+
+def test_read_cached_counts_returns_none_on_partial_cache(tmp_db, db):
+    # Arrange — cache row for only ONE of the three tracked tables
+    conn = sqlite3.connect(str(tmp_db))
+    conn.execute(
+        "CREATE TABLE db_stats (table_name TEXT PRIMARY KEY, "
+        "row_count INTEGER, computed_at TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO db_stats VALUES ('works', 5, '2026-07-22T00:00:00')"
+    )
+    conn.commit()
+    conn.close()
+    # Act
+    cached = read_cached_counts(db)
+    # Assert — partial coverage falls back to estimates entirely
+    assert cached is None
+
+
+# ---------- refresh_stats() ----------
+
+
+def test_refresh_stats_creates_db_stats_table(tmp_db):
+    # Arrange
+    # Act
+    refresh_stats(db_path=tmp_db)
+    # Assert
+    conn = sqlite3.connect(str(tmp_db))
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name='db_stats'"
+    ).fetchone()
+    conn.close()
+    assert row is not None
+
+
+def test_refresh_stats_returns_exact_works_count(tmp_db):
+    # Arrange
+    # Act
+    counts = refresh_stats(db_path=tmp_db)
+    # Assert
+    assert counts["works"] == WORKS_ROWS
+
+
+def test_refresh_stats_returns_exact_fts_count(tmp_db):
+    # Arrange
+    # Act
+    counts = refresh_stats(db_path=tmp_db)
+    # Assert
+    assert counts["fts_indexed"] == FTS_ROWS
+
+
+def test_refresh_stats_returns_exact_citations_count(tmp_db):
+    # Arrange
+    # Act
+    counts = refresh_stats(db_path=tmp_db)
+    # Assert
+    assert counts["citations"] == CITATION_ROWS
+
+
+def test_refresh_stats_labels_source_exact(tmp_db):
+    # Arrange
+    # Act
+    counts = refresh_stats(db_path=tmp_db)
+    # Assert
+    assert counts["counts_source"] == "exact"
+
+
+def test_refresh_stats_records_computed_at_timestamp(tmp_db):
+    # Arrange
+    # Act
+    counts = refresh_stats(db_path=tmp_db)
+    # Assert
+    assert counts["counts_computed_at"] is not None
+
+
+def test_refresh_stats_reflects_deletes_exactly(tmp_db):
+    # Arrange
+    conn = sqlite3.connect(str(tmp_db))
+    conn.execute("DELETE FROM works WHERE id = 2")
+    conn.commit()
+    conn.close()
+    # Act
+    counts = refresh_stats(db_path=tmp_db)
+    # Assert — COUNT(*) sees the delete (MAX(rowid) would not)
+    assert counts["works"] == WORKS_ROWS - 1
+
+
+def test_refresh_stats_records_zero_for_missing_citations_table(tmp_path):
+    # Arrange — minimal DB without a citations table
+    path = tmp_path / "no_citations.db"
+    conn = sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE works (id INTEGER PRIMARY KEY, doi TEXT)")
+    conn.execute("CREATE VIRTUAL TABLE works_fts USING fts5(title)")
+    conn.commit()
+    conn.close()
+    # Act
+    counts = refresh_stats(db_path=path)
+    # Assert
+    assert counts["citations"] == 0
+
+
+# ---------- cache read path ----------
+
+
+def test_get_counts_with_cache_labels_source_exact(tmp_db, db):
+    # Arrange
+    refresh_stats(db_path=tmp_db)
+    # Act
+    counts = get_counts(db)
+    # Assert
+    assert counts["counts_source"] == "exact"
+
+
+def test_get_counts_with_cache_returns_cached_values_not_recomputed(
+    tmp_db, db
+):
+    # Arrange — plant a sentinel value directly in the cache
+    refresh_stats(db_path=tmp_db)
+    conn = sqlite3.connect(str(tmp_db))
+    conn.execute(
+        "UPDATE db_stats SET row_count = 424242 WHERE table_name = 'works'"
+    )
+    conn.commit()
+    conn.close()
+    # Act
+    counts = get_counts(db)
+    # Assert — the cache is READ, never recomputed on this path
+    assert counts["works"] == 424242
+
+
+def test_get_counts_with_cache_reports_computed_at(tmp_db, db):
+    # Arrange
+    refresh_stats(db_path=tmp_db)
+    # Act
+    counts = get_counts(db)
+    # Assert
+    assert counts["counts_computed_at"] is not None
+
+
+# ---------- info() end-to-end (DB mode) ----------
+
+
+def test_info_without_cache_labels_counts_estimated(configured_info):
+    # Arrange
+    # Act
+    result = configured_info()
+    # Assert
+    assert result["counts_source"] == "estimated"
+
+
+def test_info_without_cache_reports_estimated_works(configured_info):
+    # Arrange
+    # Act
+    result = configured_info()
+    # Assert
+    assert result["works"] == WORKS_ROWS
+
+
+def test_info_keeps_backward_compatible_keys(configured_info):
+    # Arrange
+    # Act
+    result = configured_info()
+    # Assert
+    assert {"works", "fts_indexed", "citations", "mode", "status",
+            "db_path"} <= set(result)
+
+
+def test_info_with_cache_labels_counts_exact(tmp_db, configured_info):
+    # Arrange
+    refresh_stats(db_path=tmp_db)
+    close_db()  # drop the thread-local connection so the cache is seen
+    # Act
+    result = configured_info()
+    # Assert
+    assert result["counts_source"] == "exact"
+
+
+def test_info_with_cache_reports_exact_citations(tmp_db, configured_info):
+    # Arrange
+    refresh_stats(db_path=tmp_db)
+    close_db()
+    # Act
+    result = configured_info()
+    # Assert
+    assert result["citations"] == CITATION_ROWS
+
+# EOF


### PR DESCRIPTION
# feat: info() never full-scans — db_stats exact-count cache + labelled estimates

## Motivation (production measurements, 2026-07-22)

`crossref_local.info()` (DB mode) ran `SELECT COUNT(*)` on every call:

| table | rows | COUNT(*) time |
|---|---|---|
| `works` | 167,008,748 | 0.42 s |
| `works_fts` | (FTS5 — scans everything) | **12.70 s** |
| `citations` | 1,788,599,072 | 4.35 s |

≈ **17.5 s per call**, which made the hub's `/server-status/` page take 17–21 s TTFB.
`SELECT MAX(rowid) FROM works` returns the same number in **0.02 s**. After this
change, `info()` on the fixture DB returns in **~2 ms** with exact cached counts.

## What changed

- **New `_core/stats.py`** — cache table
  `db_stats(table_name TEXT PRIMARY KEY, row_count INTEGER, computed_at TEXT)`
  in the same SQLite DB.
  - `get_counts()` (the read path): cache first (`counts_source: "exact"`),
    else `MAX(rowid)` estimates (`counts_source: "estimated"`). NEVER
    `COUNT(*)`, NEVER writes — read-only deployments keep working; an
    estimate is never silently presented as exact.
  - `refresh_stats()` (the only write path): exact `COUNT(*)` per table →
    cache upsert. Public API (`crossref_local.refresh_stats`).
- **`info()`** (sync DB branch, `aio.info()`, and the HTTP-mode client) now
  report `counts_source` + `counts_computed_at`; the http branch labels
  old-server responses `"estimated"` and timeouts `"unavailable"`.
- **HTTP `/info`** (`_server/__init__.py`) uses the same stats-cache read
  path; `InfoResponse` gains `counts_source` / `counts_computed_at`
  (defaults keep older clients compatible).
- **CLI**: new `crossref-local refresh-stats [--db PATH] [--json]`
  (own module `_cli/stats.py`, mirroring the `update.py` extraction).
- **Ingest wiring**: `scripts/database/10_differential_update.py` refreshes
  `db_stats` after a successful sync (loud warning + manual-command hint if
  `crossref_local` is not importable).
- Backward compatible: `works`, `fts_indexed`, `citations`, `mode`,
  `status`, `db_path` keys unchanged; version 0.7.6 → 0.8.0 + CHANGELOG.

## Tests

- New `tests/crossref_local/test_stats.py` (25 tests, self-contained tiny
  SQLite DBs, DB-optional in conftest): estimate path (incl. read-only DB
  file + proof the read path never creates `db_stats`), `refresh_stats()`
  exact counts / missing-table → 0 / sees deletes that `MAX(rowid)` misses,
  cache read path (sentinel value proves cache is read, not recomputed),
  partial-cache falls back to estimates, `info()` end-to-end exact vs
  estimated labelling + backward-compatible key set.
- `test_api.py` / `test_server.py`: `counts_source` present and one of
  `exact` / `estimated` (/ `unavailable` client-side).
- Full suite: **457 passed, 2 skipped, 1 failed** — the one failure is
  `tests/develop/test_audit.py` (scitex-dev audit conformance), pre-existing:
  it flags `logs/` + `docs/to_claude/` in the stale main checkout, paths that
  do not exist on this branch; develop CI `quality` has been red with the
  same audit since 2026-07-10 (run 29073666122).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWfPb5UuutekNKttoU81fu
